### PR TITLE
Mb/transformer fix

### DIFF
--- a/_pscad_libraries/PSID_Library.bakx
+++ b/_pscad_libraries/PSID_Library.bakx
@@ -21,7 +21,7 @@
     <param name="Warn" value="0" />
     <param name="Check" value="0" />
     <param name="description" value="" />
-    <param name="revisor" value="Matt Bossart, 1677681109" />
+    <param name="revisor" value="Matt Bossart, 1678996327" />
     <param name="sparsity_threshold" value="200" />
   </paramlist>
   <Layers>
@@ -223,6 +223,26 @@
       <ref link="318022853" />
       <ref link="1505833448" />
       <ref link="1971314826" />
+      <ref link="570762016" />
+      <ref link="297602395" />
+      <ref link="1007104236" />
+      <ref link="1284935718" />
+      <ref link="1864712621" />
+      <ref link="1708656929" />
+      <ref link="426743652" />
+      <ref link="1940391173" />
+      <ref link="873241022" />
+      <ref link="1446627256" />
+      <ref link="2094957855" />
+      <ref link="528497647" />
+      <ref link="643681337" />
+      <ref link="866164788" />
+      <ref link="657639762" />
+      <ref link="1874700434" />
+      <ref link="461920702" />
+      <ref link="2010443872" />
+      <ref link="1933987607" />
+      <ref link="250107898" />
     </Layer>
     <Layer id="1308682824" classid="Layer" name="dev" state="disabled">
       <paramlist>
@@ -15149,7 +15169,7 @@
     </Settings>
   </List>
   <definitions>
-    <Definition classid="UserCmpDefn" name="simple_brk_logic" build="" crc="9123072" view="false" instances="0" date="0" id="407277916" w="320" h="400">
+    <Definition classid="UserCmpDefn" name="simple_brk_logic" build="" crc="48880174" view="false" instances="0" date="1678996051" id="407277916" w="320" h="400">
       <paramlist>
         <param name="Description" value="" />
       </paramlist>
@@ -15237,13 +15257,8 @@
           <param name="virtual_filter" value="" />
           <param name="animation_freq" value="500" />
         </paramlist>
-        <User id="1957961194" classid="UserCmp" defn="master:export" x="72" y="36" h="24" w="99" z="-1" q="4" orient="0" link="-1" disable="false">
-          <paramlist name="" link="-1" crc="68967217">
-            <param name="Name" value="brk_name" />
-          </paramlist>
-        </User>
         <grouping />
-        <User classid="UserCmp" id="1479431654" name="master:tbreakn" x="702" y="720" w="78" h="59" z="-1" orient="4" defn="master:tbreakn" link="-1" q="4" disable="false">
+        <User classid="UserCmp" id="1479431654" name="master:tbreakn" x="702" y="720" w="78" h="59" z="20" orient="4" defn="master:tbreakn" link="-1" q="4" disable="false">
           <paramlist name="" link="-1" crc="130641473">
             <param name="Name" value="" />
             <param name="NUMS" value="1" />
@@ -15252,14 +15267,14 @@
             <param name="TO2" value="1.05" />
           </paramlist>
         </User>
-        <User classid="UserCmp" id="84255800" name="master:consti" x="738" y="756" w="76" h="22" z="-1" orient="0" defn="master:consti" link="-1" q="4" disable="false">
+        <User classid="UserCmp" id="84255800" name="master:consti" x="738" y="756" w="76" h="22" z="30" orient="0" defn="master:consti" link="-1" q="4" disable="false">
           <paramlist name="" link="-1" crc="74846674">
             <param name="Name" value="" />
             <param name="Value" value="0" />
             <param name="Dim" value="1" />
           </paramlist>
         </User>
-        <User classid="UserCmp" id="778045240" name="master:select" x="810" y="756" w="82" h="91" z="-1" orient="0" defn="master:select" link="-1" q="4" disable="false">
+        <User classid="UserCmp" id="778045240" name="master:select" x="810" y="756" w="82" h="91" z="50" orient="0" defn="master:select" link="-1" q="4" disable="false">
           <paramlist name="" link="-1" crc="108938206">
             <param name="Name" value="" />
             <param name="A" value="1" />
@@ -15273,12 +15288,12 @@
             <param name="Name" value="enable" />
           </paramlist>
         </User>
-        <User classid="UserCmp" id="1012637499" name="master:import" x="702" y="666" w="89" h="25" z="40" orient="0" defn="master:import" link="-1" q="4" disable="false">
+        <User classid="UserCmp" id="1012637499" name="master:import" x="702" y="666" w="89" h="25" z="10" orient="0" defn="master:import" link="-1" q="4" disable="false">
           <paramlist name="" link="-1" crc="117509081">
             <param name="Name" value="t_break" />
           </paramlist>
         </User>
-        <User classid="UserCmp" id="1517982401" name="master:export" x="882" y="756" w="123" h="24" z="100" orient="4" defn="master:export" link="-1" q="4" disable="false">
+        <User classid="UserCmp" id="1517982401" name="master:export" x="882" y="756" w="123" h="24" z="60" orient="4" defn="master:export" link="-1" q="4" disable="false">
           <paramlist name="" link="-1" crc="68967217">
             <param name="Name" value="breaker_name" />
           </paramlist>
@@ -15294,7 +15309,7 @@
         </Wire>
       </schematic>
     </Definition>
-    <Definition classid="UserCmpDefn" name="LCLFilter" build="" crc="68159700" view="false" instances="0" date="1677209045" id="1618076215" w="320" h="400" url="" group="">
+    <Definition classid="UserCmpDefn" name="LCLFilter" build="" crc="68159700" view="false" instances="0" date="1678996054" id="1618076215" w="320" h="400" url="" group="">
       <paramlist>
         <param name="Description" value="" />
       </paramlist>
@@ -17935,7 +17950,7 @@
         </Frame>
       </schematic>
     </Definition>
-    <Definition classid="UserCmpDefn" name="ReferenceFrameConversion_INV" build="" crc="17498588" view="false" instances="0" date="1677209045" id="1427823627" w="320" h="400" url="" group="">
+    <Definition classid="UserCmpDefn" name="ReferenceFrameConversion_INV" build="" crc="17498588" view="false" instances="0" date="1678996054" id="1427823627" w="320" h="400" url="" group="">
       <paramlist>
         <param name="Description" value="" />
       </paramlist>
@@ -18988,7 +19003,7 @@
         </User>
       </schematic>
     </Definition>
-    <Definition classid="UserCmpDefn" name="ActivePI_ReactivePI" group="" url="" version="" build="" crc="20054363" instances="0" key="" view="false" date="1677209046" id="1023623776">
+    <Definition classid="UserCmpDefn" name="ActivePI_ReactivePI" group="" url="" version="" build="" crc="20054363" instances="0" key="" view="false" date="1678996056" id="1023623776">
       <paramlist name="">
         <param name="Description" value="" />
       </paramlist>
@@ -21122,7 +21137,7 @@
         </Gfx>
       </graphics>
     </Definition>
-    <Definition classid="UserCmpDefn" name="CurrentModeControl" group="" url="" version="" build="" crc="121687851" instances="0" key="" view="false" date="1677209047" id="700101540">
+    <Definition classid="UserCmpDefn" name="CurrentModeControl" group="" url="" version="" build="" crc="121687851" instances="0" key="" view="false" date="1678996057" id="700101540">
       <paramlist name="">
         <param name="Description" value="" />
       </paramlist>
@@ -23320,7 +23335,7 @@
         </Gfx>
       </graphics>
     </Definition>
-    <Definition classid="UserCmpDefn" name="ActiveDroop_ReactiveDroop" group="" url="" version="" build="" crc="49001422" instances="0" key="" view="false" date="1677209049" id="1143056703">
+    <Definition classid="UserCmpDefn" name="ActiveDroop_ReactiveDroop" group="" url="" version="" build="" crc="49001422" instances="0" key="" view="false" date="1678996055" id="1143056703">
       <paramlist name="">
         <param name="Description" value="" />
       </paramlist>
@@ -25157,7 +25172,7 @@
         </Gfx>
       </graphics>
     </Definition>
-    <Definition classid="UserCmpDefn" name="FixedFrequency" group="" url="" version="" build="" crc="23884893" instances="0" key="" view="false" date="1677209048" id="1637480071">
+    <Definition classid="UserCmpDefn" name="FixedFrequency" group="" url="" version="" build="" crc="23884893" instances="0" key="" view="false" date="1678996055" id="1637480071">
       <paramlist name="">
         <param name="Description" value="" />
       </paramlist>
@@ -33008,7 +33023,7 @@ https://www.powerworld.com/WebHelp/Content/TransientModels_HTML/Exciter%20IEEET1
         </Gfx>
       </graphics>
     </Definition>
-    <Definition classid="UserCmpDefn" name="ri_abc" group="" url="" version="" build="" crc="39743059" instances="0" key="" view="false" date="1677209046" id="1279234079">
+    <Definition classid="UserCmpDefn" name="ri_abc" group="" url="" version="" build="" crc="39743059" instances="0" key="" view="false" date="1678996055" id="1279234079">
       <paramlist name="">
         <param name="Description" value="" />
       </paramlist>
@@ -36472,7 +36487,7 @@ https://www.powerworld.com/WebHelp/Content/TransientModels_HTML/Exciter%20IEEET1
         </Gfx>
       </graphics>
     </Definition>
-    <Definition classid="UserCmpDefn" name="FixedDCSource" group="" url="" version="" build="" crc="54267588" instances="0" key="" view="false" date="1677209044" id="40583395">
+    <Definition classid="UserCmpDefn" name="FixedDCSource" group="" url="" version="" build="" crc="54267588" instances="0" key="" view="false" date="1678996054" id="40583395">
       <paramlist name="">
         <param name="Description" value="" />
       </paramlist>
@@ -36815,7 +36830,7 @@ https://www.powerworld.com/WebHelp/Content/TransientModels_HTML/Exciter%20IEEET1
         </Gfx>
       </graphics>
     </Definition>
-    <Definition classid="UserCmpDefn" name="AverageConverter" group="" url="" version="" build="" crc="59710214" instances="0" key="" view="false" date="1677209047" id="467840428">
+    <Definition classid="UserCmpDefn" name="AverageConverter" group="" url="" version="" build="" crc="59710214" instances="0" key="" view="false" date="1678996056" id="467840428">
       <paramlist name="">
         <param name="Description" value="" />
       </paramlist>
@@ -37217,7 +37232,7 @@ https://www.powerworld.com/WebHelp/Content/TransientModels_HTML/Exciter%20IEEET1
         </Gfx>
       </graphics>
     </Definition>
-    <Definition classid="UserCmpDefn" name="KauraPLL" group="" url="" version="" build="" crc="31163226" instances="0" key="" view="false" date="1677209044" id="1511733146">
+    <Definition classid="UserCmpDefn" name="KauraPLL" group="" url="" version="" build="" crc="31163226" instances="0" key="" view="false" date="1678996056" id="1511733146">
       <paramlist name="">
         <param name="Description" value="" />
       </paramlist>
@@ -38404,7 +38419,7 @@ https://www.powerworld.com/WebHelp/Content/TransientModels_HTML/Exciter%20IEEET1
         </Gfx>
       </graphics>
     </Definition>
-    <Definition classid="UserCmpDefn" name="VoltageModeControl" group="" url="" version="" build="" crc="128886027" instances="0" key="" view="false" date="1677209049" id="248922385">
+    <Definition classid="UserCmpDefn" name="VoltageModeControl" group="" url="" version="" build="" crc="128886027" instances="0" key="" view="false" date="1678996055" id="248922385">
       <paramlist name="">
         <param name="Description" value="" />
       </paramlist>
@@ -44209,7 +44224,7 @@ Milano, page 359
         <grouping />
       </schematic>
     </Definition>
-    <Definition classid="UserCmpDefn" name="Main" id="1166570604" group="" url="" version="" build="" crc="41903428" view="false" date="0">
+    <Definition classid="UserCmpDefn" name="Main" id="1166570604" group="" url="" version="" build="" crc="58573924" view="false" date="0">
       <paramlist name="">
         <param name="Description" value="" />
       </paramlist>
@@ -46094,7 +46109,7 @@ https://info.ornl.gov/sites/publications/files/Pub47049.pdf]]></Sticky>
             <param name="ymax" value="1" />
           </paramlist>
         </User>
-        <User classid="UserCmp" id="302217636" name="PSID_Library:volley_circuit_breaker_logic" x="2268" y="918" w="98" h="66" z="-1" orient="0" defn="PSID_Library:volley_circuit_breaker_logic" link="-1" q="4" disable="false">
+        <User classid="UserCmp" id="302217636" name="PSID_Library:volley_circuit_breaker_logic" x="2268" y="918" w="98" h="63" z="-1" orient="0" defn="PSID_Library:volley_circuit_breaker_logic" link="-1" q="4" disable="false">
           <paramlist name="" link="-1" crc="17490394">
             <param name="Name" value="" />
           </paramlist>
@@ -48194,7 +48209,7 @@ https://www.phasetophase.nl/pdf/SynchronousMachineTurbineGoverningSystems.pdf]]>
         </Gfx>
       </graphics>
     </Definition>
-    <Definition classid="UserCmpDefn" name="ReferenceFrameConversion_GEN" build="" crc="1322555" view="false" instances="0" date="1677209038" id="2058478115" w="320" h="400" url="" group="">
+    <Definition classid="UserCmpDefn" name="ReferenceFrameConversion_GEN" build="" crc="1322555" view="false" instances="0" date="1678996051" id="2058478115" w="320" h="400" url="" group="">
       <paramlist>
         <param name="Description" value="" />
       </paramlist>
@@ -48619,7 +48634,7 @@ https://www.phasetophase.nl/pdf/SynchronousMachineTurbineGoverningSystems.pdf]]>
         </Wire>
       </schematic>
     </Definition>
-    <Definition classid="UserCmpDefn" name="SauerPaiMachine" build="" crc="18675565" view="false" instances="0" date="1677209042" id="1825217716" w="320" h="400" url="" group="">
+    <Definition classid="UserCmpDefn" name="SauerPaiMachine" build="" crc="18675565" view="false" instances="0" date="1678996053" id="1825217716" w="320" h="400" url="" group="">
       <paramlist>
         <param name="Description" value="" />
       </paramlist>
@@ -51314,7 +51329,7 @@ https://www.phasetophase.nl/pdf/SynchronousMachineTurbineGoverningSystems.pdf]]>
         </Wire>
       </schematic>
     </Definition>
-    <Definition classid="UserCmpDefn" name="CurrentSourceInterface" build="" crc="112498156" view="false" instances="0" date="1677209043" id="600557575" w="320" h="400" url="" group="">
+    <Definition classid="UserCmpDefn" name="CurrentSourceInterface" build="" crc="112498156" view="false" instances="0" date="1678996053" id="600557575" w="320" h="400" url="" group="">
       <paramlist>
         <param name="Description" value="" />
       </paramlist>
@@ -53274,7 +53289,7 @@ What is the characteristic impedance?
         </User>
       </schematic>
     </Definition>
-    <Definition classid="UserCmpDefn" name="SingleMass" build="" crc="107558810" view="false" instances="0" date="1677209041" id="1780857034" w="320" h="400" url="" group="">
+    <Definition classid="UserCmpDefn" name="SingleMass" build="" crc="107558810" view="false" instances="0" date="1678996053" id="1780857034" w="320" h="400" url="" group="">
       <paramlist>
         <param name="Description" value="" />
       </paramlist>
@@ -54360,7 +54375,7 @@ Need to test.
         </Wire>
       </schematic>
     </Definition>
-    <Definition classid="UserCmpDefn" name="abc_dq_psid" group="" url="" version="" build="" crc="18298543" instances="0" key="" view="false" date="1677209040" id="1690178130">
+    <Definition classid="UserCmpDefn" name="abc_dq_psid" group="" url="" version="" build="" crc="18298543" instances="0" key="" view="false" date="1678996052" id="1690178130">
       <paramlist name="">
         <param name="Description" value="" />
       </paramlist>
@@ -55106,7 +55121,7 @@ Need to test.
         </Gfx>
       </graphics>
     </Definition>
-    <Definition classid="UserCmpDefn" name="dq_abc_psid" group="" url="" version="" build="" crc="79563412" instances="0" key="" view="false" date="1677209039" id="1213191902">
+    <Definition classid="UserCmpDefn" name="dq_abc_psid" group="" url="" version="" build="" crc="79563412" instances="0" key="" view="false" date="1678996052" id="1213191902">
       <paramlist name="">
         <param name="Description" value="" />
       </paramlist>
@@ -55849,7 +55864,7 @@ Need to test.
         </Gfx>
       </graphics>
     </Definition>
-    <Definition classid="UserCmpDefn" name="timestep_delay_angle" group="" url="" version="" build="" crc="66017651" instances="0" key="" view="false" date="1677209039" id="913401546">
+    <Definition classid="UserCmpDefn" name="timestep_delay_angle" group="" url="" version="" build="" crc="66017651" instances="0" key="" view="false" date="1678996052" id="913401546">
       <paramlist name="">
         <param name="Description" value="" />
       </paramlist>
@@ -56081,7 +56096,7 @@ Need to test.
         </Gfx>
       </graphics>
     </Definition>
-    <Definition classid="UserCmpDefn" name="SEXS" build="" crc="12173782" view="false" instances="0" date="1677209040" id="990107576" w="320" h="400" url="" group="">
+    <Definition classid="UserCmpDefn" name="SEXS" build="" crc="12173782" view="false" instances="0" date="1678996052" id="990107576" w="320" h="400" url="" group="">
       <paramlist>
         <param name="Description" value="" />
       </paramlist>
@@ -56741,7 +56756,7 @@ Need to test.
         </Wire>
       </schematic>
     </Definition>
-    <Definition classid="UserCmpDefn" name="PSSFixed" build="" crc="133247180" view="false" instances="0" date="1677209042" id="360526612" w="320" h="400" url="" group="">
+    <Definition classid="UserCmpDefn" name="PSSFixed" build="" crc="133247180" view="false" instances="0" date="1678996053" id="360526612" w="320" h="400" url="" group="">
       <paramlist>
         <param name="Description" value="" />
       </paramlist>
@@ -60075,7 +60090,7 @@ Need to test.
         </User>
       </schematic>
     </Definition>
-    <Definition classid="UserCmpDefn" name="SteamTurbineGov1" build="" crc="112176012" view="false" instances="0" date="1677209041" id="1132640844" w="320" h="400" url="" group="">
+    <Definition classid="UserCmpDefn" name="SteamTurbineGov1" build="" crc="61852898" view="false" instances="0" date="1678996052" id="1132640844" w="320" h="400" url="" group="">
       <paramlist>
         <param name="Description" value="" />
       </paramlist>
@@ -60694,92 +60709,6 @@ Need to test.
             <param name="Name" value="debug1" />
           </paramlist>
         </User>
-        <User classid="UserCmp" name="master:datalabel" id="2086966281" x="864" y="396" w="48" h="23" z="1" orient="4" defn="master:datalabel" link="-1" q="4" disable="false">
-          <paramlist link="-1" name="" crc="127230955">
-            <param name="Name" value="debug1" />
-          </paramlist>
-        </User>
-        <User classid="UserCmp" id="251615959" name="master:pgb" x="864" y="396" w="59" h="40" z="260" orient="0" defn="master:pgb" link="-1" q="4" disable="false">
-          <paramlist name="" link="-1" crc="65740200">
-            <param name="Name" value="debug1" />
-            <param name="Group" value="" />
-            <param name="UseSignalName" value="1" />
-            <param name="enab" value="1" />
-            <param name="Display" value="1" />
-            <param name="Scale" value="1.0" />
-            <param name="Units" value="" />
-            <param name="mrun" value="0" />
-            <param name="Pol" value="0" />
-            <param name="Max" value="2.0" />
-            <param name="Min" value="-2.0" />
-          </paramlist>
-        </User>
-        <Frame classid="GraphFrame" id="933491522" name="frame" link="-1" x="1080" y="342" w="576" h="288">
-          <paramlist link="-1" name="">
-            <param name="Icon" value="-1,0" />
-            <param name="state" value="1" />
-            <param name="title" value="$(GROUP) : Graphs" />
-            <param name="XLabel" value="sec" />
-            <param name="Pan" value="false" />
-            <param name="pan_enable" value="false" />
-            <param name="pan_amount" value="75" />
-            <param name="markers" value="false" />
-            <param name="glyphs" value="false" />
-            <param name="ticks" value="false" />
-            <param name="grid" value="false" />
-            <param name="yinter" value="false" />
-            <param name="xinter" value="false" />
-            <param name="semilog" value="false" />
-            <param name="snapaperture" value="false" />
-            <param name="dynaperture" value="true" />
-            <param name="minorgrids" value="false" />
-            <param name="lockmarkers" value="false" />
-            <param name="deltareadout" value="false" />
-            <param name="xmarker" value="0" />
-            <param name="omarker" value="0" />
-            <param name="xfont" value="Tahoma, 12world" />
-            <param name="xangle" value="0" />
-            <param name="xtitle" value="sec" />
-            <param name="xgridauto" value="true" />
-            <param name="xgrid" value="0.1" />
-          </paramlist>
-          <paramlist name="" link="933491522">
-            <param name="xmin" value="0.000000" />
-            <param name="xmax" value="1.000000" />
-          </paramlist>
-          <Graph classid="OverlayGraph" id="1899027869" link="-1">
-            <paramlist link="-1" name="">
-              <param name="title" value="" />
-              <param name="units" value="" />
-              <param name="gridvalue" value="0.1" />
-              <param name="yintervalue" value="0" />
-              <param name="grid" value="true" />
-              <param name="ticks" value="false" />
-              <param name="glyphs" value="false" />
-              <param name="yinter" value="true" />
-              <param name="xinter" value="true" />
-              <param name="marker" value="false" />
-              <param name="trigger" value="false" />
-              <param name="invertcolor" value="false" />
-              <param name="crosshair" value="false" />
-              <param name="manualscale" value="false" />
-              <param name="autoframe" value="10" />
-              <param name="grid_color" value="#FF95908C" />
-              <param name="curve_colours" value="Navy;Green;Maroon;Teal;Purple;Brown" />
-              <param name="curve_colours2" value="Blue;Lime;Red;Aqua;Fuchsia;Yellow" />
-            </paramlist>
-            <paramlist name="" link="1899027869">
-              <param name="ymin" value="-1" />
-              <param name="ymax" value="1" />
-            </paramlist>
-            <Curve classid="Curve" id="2106466990" name="debug1" link="251615959" color="0" bold="0" show="-1" mode="0" gradient="false" transparency="255" thresh="0.5" above="High" below="Low" style="0">
-              <path />
-            </Curve>
-            <Curve classid="Curve" id="1008639123" name="tau_m" link="250107898" color="0" bold="0" show="-1" mode="0" gradient="false" transparency="255" thresh="0.5" above="High" below="Low" style="0">
-              <path />
-            </Curve>
-          </Graph>
-        </Frame>
         <User classid="UserCmp" name="master:datalabel" id="1933987607" x="864" y="486" w="24" h="23" z="1" orient="4" defn="master:datalabel" link="-1" q="4" disable="false">
           <paramlist link="-1" name="" crc="127230955">
             <param name="Name" value="tau" />
@@ -60818,38 +60747,36 @@ Need to test.
     </paramlist>
   </GlobalSubstitutions>
   <hierarchy>
-    <call link="1774770651" name="PSID_Library:Station" z="-1" view="false" instance="0">
-      <call link="1121605733" name="PSID_Library:Main" z="-1" view="false" instance="0">
-        <call link="590877718" name="PSID_Library:TGOV1" z="-1" view="false" instance="0" />
+    <call link="660002259" name="PSID_Library:Station" z="-1" view="false" instance="0">
+      <call link="1121605733" name="PSID_Library:Main" z="-1" view="true" instance="0">
+        <call link="1900225599" name="PSID_Library:TGTypeII" z="-1" view="false" instance="0" />
+        <call link="1212736682" name="PSID_Library:KauraPLL" z="-1" view="false" instance="0">
+          <call link="2065055101" name="PSID_Library:timestep_delay_angle" z="330" view="false" instance="0" />
+          <call link="1583651100" name="PSID_Library:abc_dq_psid" z="340" view="false" instance="0" />
+        </call>
         <call link="791628388" name="PSID_Library:AverageConverter" z="-1" view="false" instance="0" />
         <call link="353908200" name="PSID_Library:FixedDCSource" z="-1" view="false" instance="0" />
         <call link="117063645" name="PSID_Library:dq_ri" z="-1" view="false" instance="0" />
-        <call link="1536472840" name="PSID_Library:ri_dq" z="-1" view="false" instance="0" />
-        <call link="970744943" name="PSID_Library:ri_abc" z="-1" view="false" instance="0" />
         <call link="1935923328" name="PSID_Library:VirtualInertia_ReactiveDroop" z="-1" view="false" instance="0" />
-        <call link="1711448333" name="PSID_Library:magangle_ri" z="-1" view="false" instance="0" />
+        <call link="970744943" name="PSID_Library:ri_abc" z="-1" view="false" instance="0" />
         <call link="920231050" name="PSID_Library:IEEET1" z="-1" view="false" instance="0">
           <call link="1513031148" name="PSID_Library:exciter_saturation" z="140" view="false" instance="0" />
           <call link="746068508" name="PSID_Library:exciter_saturation" z="360" view="false" instance="1" />
         </call>
+        <call link="573480777" name="PSID_Library:exciter_saturation" z="-1" view="false" instance="2" />
+        <call link="1749606776" name="PSID_Library:AVRSimple" z="-1" view="false" instance="0" />
         <call link="32368114" name="PSID_Library:BPA_GG" z="-1" view="false" instance="0" />
         <call link="1257164115" name="PSID_Library:GGOV1" z="-1" view="false" instance="0">
           <call link="471511252" name="PSID_Library:DeadBand" z="890" view="false" instance="0" />
         </call>
-        <call link="289925425" name="PSID_Library:SEXS_2" z="-1" view="false" instance="0" />
+        <call link="1711448333" name="PSID_Library:magangle_ri" z="-1" view="false" instance="0" />
+        <call link="1536472840" name="PSID_Library:ri_dq" z="-1" view="false" instance="0" />
+        <call link="1997484035" name="PSID_Library:VoltageModeControl" z="-1" view="false" instance="0" />
         <call link="1584018673" name="PSID_Library:DeadBand" z="-1" view="false" instance="1" />
-        <call link="1749606776" name="PSID_Library:AVRSimple" z="-1" view="false" instance="0" />
+        <call link="289925425" name="PSID_Library:SEXS_2" z="-1" view="false" instance="0" />
         <call link="1496654770" name="PSID_Library:RateLimiter" z="-1" view="false" instance="0" />
         <call link="1868501625" name="PSID_Library:FixedFrequency" z="-1" view="false" instance="0" />
-        <call link="1900225599" name="PSID_Library:TGTypeII" z="-1" view="false" instance="0" />
-        <call link="1340636822" name="PSID_Library:ActiveDroop_ReactiveDroop" z="-1" view="false" instance="0" />
-        <call link="285503644" name="PSID_Library:ReducedOrderPLL" z="-1" view="false" instance="0">
-          <call link="975203037" name="PSID_Library:abc_dq_psid" z="200" view="false" instance="0" />
-          <call link="1708939662" name="PSID_Library:timestep_delay_angle" z="300" view="false" instance="0" />
-        </call>
-        <call link="1689773799" name="PSID_Library:ActivePI_ReactivePI" z="-1" view="false" instance="0" />
-        <call link="302217636" name="PSID_Library:volley_circuit_breaker_logic" z="-1" view="false" instance="0" />
-        <call link="1099669844" name="PSID_Library:GAST_2" z="-1" view="false" instance="0" />
+        <call link="771555009" name="PSID_Library:CurrentModeControl" z="-1" view="false" instance="0" />
         <call link="1093407088" name="PSID_Library:ReferenceFrameConversion_INV" z="-1" view="false" instance="0">
           <call link="1686720077" name="PSID_Library:timestep_delay_angle" z="60" view="false" instance="1" />
           <call link="1115078297" name="PSID_Library:dq_abc_psid" z="70" view="false" instance="0" />
@@ -60860,37 +60787,39 @@ Need to test.
         <call link="1585140405" name="PSID_Library:LCLFilter" z="-1" view="false" instance="0">
           <call link="645843216" name="PSID_Library:ri_abc" z="890" view="false" instance="1" />
         </call>
-        <call link="771555009" name="PSID_Library:CurrentModeControl" z="-1" view="false" instance="0" />
-        <call link="417400883" name="PSID_Library:SauerPaiMachine" z="-1" view="false" instance="0" />
-        <call link="1883499949" name="PSID_Library:CurrentSourceInterface" z="-1" view="false" instance="0" />
-        <call link="573480777" name="PSID_Library:exciter_saturation" z="-1" view="false" instance="2" />
-        <call link="85566424" name="PSID_Library:AVRFixed" z="-1" view="false" instance="0" />
-        <call link="457892986" name="PSID_Library:SingleMass" z="-1" view="false" instance="0" />
-        <call link="1980808861" name="PSID_Library:TGFixed" z="-1" view="false" instance="0" />
-        <call link="1518507892" name="PSID_Library:dq_abc_psid" z="-1" view="false" instance="1" />
-        <call link="691555753" name="PSID_Library:HydroTurbineGov" z="-1" view="false" instance="0" />
-        <call link="40718861" name="PSID_Library:SEXS" z="-1" view="false" instance="0" />
-        <call link="812723526" name="PSID_Library:timestep_delay_angle" z="-1" view="false" instance="2" />
-        <call link="314200446" name="PSID_Library:SteamTurbineGov1" z="-1" view="false" instance="0" />
-        <call link="1171105701" name="PSID_Library:abc_dq_psid" z="-1" view="false" instance="4" />
-        <call link="49018463" name="PSID_Library:SecOdrPole" z="-1" view="false" instance="0" />
-        <call link="1997484035" name="PSID_Library:VoltageModeControl" z="-1" view="false" instance="0" />
-        <call link="1834683724" name="PSID_Library:IEEEST" z="-1" view="false" instance="0">
-          <call link="1589910882" name="PSID_Library:SecOdrPole" z="-1" view="false" instance="1" />
-          <call link="617299442" name="PSID_Library:SecOdrPole" z="-1" view="false" instance="2" />
+        <call link="285503644" name="PSID_Library:ReducedOrderPLL" z="-1" view="false" instance="0">
+          <call link="975203037" name="PSID_Library:abc_dq_psid" z="200" view="false" instance="4" />
+          <call link="1708939662" name="PSID_Library:timestep_delay_angle" z="300" view="false" instance="2" />
         </call>
         <call link="1154150259" name="PSID_Library:ReferenceFrameConversion_GEN" z="-1" view="false" instance="0">
           <call link="1659966761" name="PSID_Library:timestep_delay_angle" z="40" view="false" instance="3" />
-          <call link="1136399958" name="PSID_Library:dq_abc_psid" z="50" view="false" instance="2" />
+          <call link="1136399958" name="PSID_Library:dq_abc_psid" z="50" view="false" instance="1" />
           <call link="1050186494" name="PSID_Library:abc_dq_psid" z="60" view="false" instance="5" />
         </call>
-        <call link="1212736682" name="PSID_Library:KauraPLL" z="-1" view="false" instance="0">
-          <call link="2065055101" name="PSID_Library:timestep_delay_angle" z="330" view="false" instance="4" />
-          <call link="1583651100" name="PSID_Library:abc_dq_psid" z="340" view="false" instance="6" />
-        </call>
+        <call link="1883499949" name="PSID_Library:CurrentSourceInterface" z="-1" view="false" instance="0" />
+        <call link="85566424" name="PSID_Library:AVRFixed" z="-1" view="false" instance="0" />
+        <call link="457892986" name="PSID_Library:SingleMass" z="-1" view="false" instance="0" />
+        <call link="1099669844" name="PSID_Library:GAST_2" z="-1" view="false" instance="0" />
+        <call link="1340636822" name="PSID_Library:ActiveDroop_ReactiveDroop" z="-1" view="false" instance="0" />
+        <call link="1980808861" name="PSID_Library:TGFixed" z="-1" view="false" instance="0" />
+        <call link="1171105701" name="PSID_Library:abc_dq_psid" z="-1" view="false" instance="6" />
+        <call link="1518507892" name="PSID_Library:dq_abc_psid" z="-1" view="false" instance="2" />
+        <call link="40718861" name="PSID_Library:SEXS" z="-1" view="false" instance="0" />
+        <call link="1689773799" name="PSID_Library:ActivePI_ReactivePI" z="-1" view="false" instance="0" />
         <call link="1779563302" name="PSID_Library:GASTG" z="-1" view="false" instance="0" />
-        <call link="789112817" name="PSID_Library:simple_brk_logic" z="-1" view="true" instance="0" />
         <call link="1728083034" name="PSID_Library:PSSFixed" z="-1" view="false" instance="0" />
+        <call link="302217636" name="PSID_Library:volley_circuit_breaker_logic" z="-1" view="false" instance="0" />
+        <call link="812723526" name="PSID_Library:timestep_delay_angle" z="-1" view="false" instance="4" />
+        <call link="417400883" name="PSID_Library:SauerPaiMachine" z="-1" view="false" instance="0" />
+        <call link="49018463" name="PSID_Library:SecOdrPole" z="-1" view="false" instance="0" />
+        <call link="314200446" name="PSID_Library:SteamTurbineGov1" z="-1" view="false" instance="0" />
+        <call link="590877718" name="PSID_Library:TGOV1" z="-1" view="false" instance="0" />
+        <call link="1834683724" name="PSID_Library:IEEEST" z="-1" view="false" instance="0">
+          <call link="617299442" name="PSID_Library:SecOdrPole" z="-1" view="false" instance="1" />
+          <call link="1589910882" name="PSID_Library:SecOdrPole" z="-1" view="false" instance="2" />
+        </call>
+        <call link="789112817" name="PSID_Library:simple_brk_logic" z="-1" view="false" instance="0" />
+        <call link="691555753" name="PSID_Library:HydroTurbineGov" z="-1" view="false" instance="0" />
       </call>
     </call>
   </hierarchy>

--- a/_pscad_libraries/PSID_Library.pslx
+++ b/_pscad_libraries/PSID_Library.pslx
@@ -21,7 +21,7 @@
     <param name="Warn" value="0" />
     <param name="Check" value="0" />
     <param name="description" value="" />
-    <param name="revisor" value="Matt Bossart, 1677681130" />
+    <param name="revisor" value="Matt Bossart, 1678996562" />
     <param name="sparsity_threshold" value="200" />
   </paramlist>
   <Layers>
@@ -223,6 +223,29 @@
       <ref link="318022853" />
       <ref link="1505833448" />
       <ref link="1971314826" />
+      <ref link="570762016" />
+      <ref link="297602395" />
+      <ref link="1007104236" />
+      <ref link="1284935718" />
+      <ref link="1864712621" />
+      <ref link="1708656929" />
+      <ref link="426743652" />
+      <ref link="1940391173" />
+      <ref link="873241022" />
+      <ref link="1446627256" />
+      <ref link="2094957855" />
+      <ref link="528497647" />
+      <ref link="643681337" />
+      <ref link="866164788" />
+      <ref link="657639762" />
+      <ref link="1874700434" />
+      <ref link="461920702" />
+      <ref link="2010443872" />
+      <ref link="1933987607" />
+      <ref link="250107898" />
+      <ref link="1172609334" />
+      <ref link="608955653" />
+      <ref link="665939826" />
     </Layer>
     <Layer id="1308682824" classid="Layer" name="dev" state="disabled">
       <paramlist>
@@ -15149,7 +15172,7 @@
     </Settings>
   </List>
   <definitions>
-    <Definition classid="UserCmpDefn" name="simple_brk_logic" build="" crc="10627251" view="false" instances="0" date="0" id="407277916" w="320" h="400">
+    <Definition classid="UserCmpDefn" name="simple_brk_logic" build="" crc="48880174" view="false" instances="0" date="1678996377" id="407277916" w="320" h="400">
       <paramlist>
         <param name="Description" value="" />
       </paramlist>
@@ -15238,7 +15261,7 @@
           <param name="animation_freq" value="500" />
         </paramlist>
         <grouping />
-        <User classid="UserCmp" id="1479431654" name="master:tbreakn" x="702" y="720" w="78" h="59" z="-1" orient="4" defn="master:tbreakn" link="-1" q="4" disable="false">
+        <User classid="UserCmp" id="1479431654" name="master:tbreakn" x="702" y="720" w="78" h="59" z="20" orient="4" defn="master:tbreakn" link="-1" q="4" disable="false">
           <paramlist name="" link="-1" crc="130641473">
             <param name="Name" value="" />
             <param name="NUMS" value="1" />
@@ -15247,14 +15270,14 @@
             <param name="TO2" value="1.05" />
           </paramlist>
         </User>
-        <User classid="UserCmp" id="84255800" name="master:consti" x="738" y="756" w="76" h="22" z="-1" orient="0" defn="master:consti" link="-1" q="4" disable="false">
+        <User classid="UserCmp" id="84255800" name="master:consti" x="738" y="756" w="76" h="22" z="30" orient="0" defn="master:consti" link="-1" q="4" disable="false">
           <paramlist name="" link="-1" crc="74846674">
             <param name="Name" value="" />
             <param name="Value" value="0" />
             <param name="Dim" value="1" />
           </paramlist>
         </User>
-        <User classid="UserCmp" id="778045240" name="master:select" x="810" y="756" w="82" h="91" z="-1" orient="0" defn="master:select" link="-1" q="4" disable="false">
+        <User classid="UserCmp" id="778045240" name="master:select" x="810" y="756" w="82" h="91" z="50" orient="0" defn="master:select" link="-1" q="4" disable="false">
           <paramlist name="" link="-1" crc="108938206">
             <param name="Name" value="" />
             <param name="A" value="1" />
@@ -15268,12 +15291,12 @@
             <param name="Name" value="enable" />
           </paramlist>
         </User>
-        <User classid="UserCmp" id="1012637499" name="master:import" x="702" y="666" w="89" h="25" z="40" orient="0" defn="master:import" link="-1" q="4" disable="false">
+        <User classid="UserCmp" id="1012637499" name="master:import" x="702" y="666" w="89" h="25" z="10" orient="0" defn="master:import" link="-1" q="4" disable="false">
           <paramlist name="" link="-1" crc="117509081">
             <param name="Name" value="t_break" />
           </paramlist>
         </User>
-        <User classid="UserCmp" id="1517982401" name="master:export" x="882" y="756" w="123" h="24" z="100" orient="4" defn="master:export" link="-1" q="4" disable="false">
+        <User classid="UserCmp" id="1517982401" name="master:export" x="882" y="756" w="123" h="24" z="60" orient="4" defn="master:export" link="-1" q="4" disable="false">
           <paramlist name="" link="-1" crc="68967217">
             <param name="Name" value="breaker_name" />
           </paramlist>
@@ -15289,7 +15312,7 @@
         </Wire>
       </schematic>
     </Definition>
-    <Definition classid="UserCmpDefn" name="LCLFilter" build="" crc="68159700" view="false" instances="0" date="1677209045" id="1618076215" w="320" h="400" url="" group="">
+    <Definition classid="UserCmpDefn" name="LCLFilter" build="" crc="68159700" view="false" instances="0" date="1678996380" id="1618076215" w="320" h="400" url="" group="">
       <paramlist>
         <param name="Description" value="" />
       </paramlist>
@@ -17930,7 +17953,7 @@
         </Frame>
       </schematic>
     </Definition>
-    <Definition classid="UserCmpDefn" name="ReferenceFrameConversion_INV" build="" crc="17498588" view="false" instances="0" date="1677209045" id="1427823627" w="320" h="400" url="" group="">
+    <Definition classid="UserCmpDefn" name="ReferenceFrameConversion_INV" build="" crc="17498588" view="false" instances="0" date="1678996380" id="1427823627" w="320" h="400" url="" group="">
       <paramlist>
         <param name="Description" value="" />
       </paramlist>
@@ -18983,7 +19006,7 @@
         </User>
       </schematic>
     </Definition>
-    <Definition classid="UserCmpDefn" name="ActivePI_ReactivePI" group="" url="" version="" build="" crc="20054363" instances="0" key="" view="false" date="1677209046" id="1023623776">
+    <Definition classid="UserCmpDefn" name="ActivePI_ReactivePI" group="" url="" version="" build="" crc="20054363" instances="0" key="" view="false" date="1678996382" id="1023623776">
       <paramlist name="">
         <param name="Description" value="" />
       </paramlist>
@@ -21117,7 +21140,7 @@
         </Gfx>
       </graphics>
     </Definition>
-    <Definition classid="UserCmpDefn" name="CurrentModeControl" group="" url="" version="" build="" crc="121687851" instances="0" key="" view="false" date="1677209047" id="700101540">
+    <Definition classid="UserCmpDefn" name="CurrentModeControl" group="" url="" version="" build="" crc="121687851" instances="0" key="" view="false" date="1678996382" id="700101540">
       <paramlist name="">
         <param name="Description" value="" />
       </paramlist>
@@ -23315,7 +23338,7 @@
         </Gfx>
       </graphics>
     </Definition>
-    <Definition classid="UserCmpDefn" name="ActiveDroop_ReactiveDroop" group="" url="" version="" build="" crc="49001422" instances="0" key="" view="false" date="1677209049" id="1143056703">
+    <Definition classid="UserCmpDefn" name="ActiveDroop_ReactiveDroop" group="" url="" version="" build="" crc="49001422" instances="0" key="" view="false" date="1678996380" id="1143056703">
       <paramlist name="">
         <param name="Description" value="" />
       </paramlist>
@@ -25152,7 +25175,7 @@
         </Gfx>
       </graphics>
     </Definition>
-    <Definition classid="UserCmpDefn" name="FixedFrequency" group="" url="" version="" build="" crc="23884893" instances="0" key="" view="false" date="1677209048" id="1637480071">
+    <Definition classid="UserCmpDefn" name="FixedFrequency" group="" url="" version="" build="" crc="23884893" instances="0" key="" view="false" date="1678996380" id="1637480071">
       <paramlist name="">
         <param name="Description" value="" />
       </paramlist>
@@ -33003,7 +33026,7 @@ https://www.powerworld.com/WebHelp/Content/TransientModels_HTML/Exciter%20IEEET1
         </Gfx>
       </graphics>
     </Definition>
-    <Definition classid="UserCmpDefn" name="ri_abc" group="" url="" version="" build="" crc="39743059" instances="0" key="" view="false" date="1677209046" id="1279234079">
+    <Definition classid="UserCmpDefn" name="ri_abc" group="" url="" version="" build="" crc="39743059" instances="0" key="" view="false" date="1678996380" id="1279234079">
       <paramlist name="">
         <param name="Description" value="" />
       </paramlist>
@@ -36467,7 +36490,7 @@ https://www.powerworld.com/WebHelp/Content/TransientModels_HTML/Exciter%20IEEET1
         </Gfx>
       </graphics>
     </Definition>
-    <Definition classid="UserCmpDefn" name="FixedDCSource" group="" url="" version="" build="" crc="54267588" instances="0" key="" view="false" date="1677209044" id="40583395">
+    <Definition classid="UserCmpDefn" name="FixedDCSource" group="" url="" version="" build="" crc="54267588" instances="0" key="" view="false" date="1678996379" id="40583395">
       <paramlist name="">
         <param name="Description" value="" />
       </paramlist>
@@ -36810,7 +36833,7 @@ https://www.powerworld.com/WebHelp/Content/TransientModels_HTML/Exciter%20IEEET1
         </Gfx>
       </graphics>
     </Definition>
-    <Definition classid="UserCmpDefn" name="AverageConverter" group="" url="" version="" build="" crc="59710214" instances="0" key="" view="false" date="1677209047" id="467840428">
+    <Definition classid="UserCmpDefn" name="AverageConverter" group="" url="" version="" build="" crc="59710214" instances="0" key="" view="false" date="1678996381" id="467840428">
       <paramlist name="">
         <param name="Description" value="" />
       </paramlist>
@@ -37212,7 +37235,7 @@ https://www.powerworld.com/WebHelp/Content/TransientModels_HTML/Exciter%20IEEET1
         </Gfx>
       </graphics>
     </Definition>
-    <Definition classid="UserCmpDefn" name="KauraPLL" group="" url="" version="" build="" crc="31163226" instances="0" key="" view="false" date="1677209044" id="1511733146">
+    <Definition classid="UserCmpDefn" name="KauraPLL" group="" url="" version="" build="" crc="119769977" instances="0" key="" view="false" date="1678996381" id="1511733146">
       <paramlist name="">
         <param name="Description" value="" />
       </paramlist>
@@ -37330,12 +37353,12 @@ https://www.powerworld.com/WebHelp/Content/TransientModels_HTML/Exciter%20IEEET1
             <param name="Name" value="V_abc" />
           </paramlist>
         </User>
-        <User classid="UserCmp" name="master:export" id="1252948384" x="1440" y="108" w="73" h="24" z="450" orient="4" defn="master:export" link="-1" q="4" disable="false">
+        <User classid="UserCmp" name="master:export" id="1252948384" x="1440" y="108" w="73" h="24" z="380" orient="4" defn="master:export" link="-1" q="4" disable="false">
           <paramlist link="-1" name="" crc="68967217">
             <param name="Name" value="w_pll" />
           </paramlist>
         </User>
-        <User classid="UserCmp" name="master:export" id="33046346" x="1746" y="198" w="93" h="24" z="440" orient="4" defn="master:export" link="-1" q="4" disable="false">
+        <User classid="UserCmp" name="master:export" id="33046346" x="1746" y="198" w="93" h="24" z="370" orient="4" defn="master:export" link="-1" q="4" disable="false">
           <paramlist link="-1" name="" crc="68967217">
             <param name="Name" value="theta_pll" />
           </paramlist>
@@ -38399,7 +38422,7 @@ https://www.powerworld.com/WebHelp/Content/TransientModels_HTML/Exciter%20IEEET1
         </Gfx>
       </graphics>
     </Definition>
-    <Definition classid="UserCmpDefn" name="VoltageModeControl" group="" url="" version="" build="" crc="128886027" instances="0" key="" view="false" date="1677209049" id="248922385">
+    <Definition classid="UserCmpDefn" name="VoltageModeControl" group="" url="" version="" build="" crc="128886027" instances="0" key="" view="false" date="1678996381" id="248922385">
       <paramlist name="">
         <param name="Description" value="" />
       </paramlist>
@@ -44204,7 +44227,7 @@ Milano, page 359
         <grouping />
       </schematic>
     </Definition>
-    <Definition classid="UserCmpDefn" name="Main" id="1166570604" group="" url="" version="" build="" crc="41903428" view="false" date="0">
+    <Definition classid="UserCmpDefn" name="Main" id="1166570604" group="" url="" version="" build="" crc="58573924" view="false" date="0">
       <paramlist name="">
         <param name="Description" value="" />
       </paramlist>
@@ -46089,7 +46112,7 @@ https://info.ornl.gov/sites/publications/files/Pub47049.pdf]]></Sticky>
             <param name="ymax" value="1" />
           </paramlist>
         </User>
-        <User classid="UserCmp" id="302217636" name="PSID_Library:volley_circuit_breaker_logic" x="2268" y="918" w="98" h="66" z="-1" orient="0" defn="PSID_Library:volley_circuit_breaker_logic" link="-1" q="4" disable="false">
+        <User classid="UserCmp" id="302217636" name="PSID_Library:volley_circuit_breaker_logic" x="2268" y="918" w="98" h="63" z="-1" orient="0" defn="PSID_Library:volley_circuit_breaker_logic" link="-1" q="4" disable="false">
           <paramlist name="" link="-1" crc="17490394">
             <param name="Name" value="" />
           </paramlist>
@@ -48189,7 +48212,7 @@ https://www.phasetophase.nl/pdf/SynchronousMachineTurbineGoverningSystems.pdf]]>
         </Gfx>
       </graphics>
     </Definition>
-    <Definition classid="UserCmpDefn" name="ReferenceFrameConversion_GEN" build="" crc="1322555" view="false" instances="0" date="1677209038" id="2058478115" w="320" h="400" url="" group="">
+    <Definition classid="UserCmpDefn" name="ReferenceFrameConversion_GEN" build="" crc="1322555" view="false" instances="0" date="1678996377" id="2058478115" w="320" h="400" url="" group="">
       <paramlist>
         <param name="Description" value="" />
       </paramlist>
@@ -48614,7 +48637,7 @@ https://www.phasetophase.nl/pdf/SynchronousMachineTurbineGoverningSystems.pdf]]>
         </Wire>
       </schematic>
     </Definition>
-    <Definition classid="UserCmpDefn" name="SauerPaiMachine" build="" crc="18675565" view="false" instances="0" date="1677209042" id="1825217716" w="320" h="400" url="" group="">
+    <Definition classid="UserCmpDefn" name="SauerPaiMachine" build="" crc="18675565" view="false" instances="0" date="1678996379" id="1825217716" w="320" h="400" url="" group="">
       <paramlist>
         <param name="Description" value="" />
       </paramlist>
@@ -51309,7 +51332,7 @@ https://www.phasetophase.nl/pdf/SynchronousMachineTurbineGoverningSystems.pdf]]>
         </Wire>
       </schematic>
     </Definition>
-    <Definition classid="UserCmpDefn" name="CurrentSourceInterface" build="" crc="112498156" view="false" instances="0" date="1677209043" id="600557575" w="320" h="400" url="" group="">
+    <Definition classid="UserCmpDefn" name="CurrentSourceInterface" build="" crc="112498156" view="false" instances="0" date="1678996379" id="600557575" w="320" h="400" url="" group="">
       <paramlist>
         <param name="Description" value="" />
       </paramlist>
@@ -53269,7 +53292,7 @@ What is the characteristic impedance?
         </User>
       </schematic>
     </Definition>
-    <Definition classid="UserCmpDefn" name="SingleMass" build="" crc="107558810" view="false" instances="0" date="1677209041" id="1780857034" w="320" h="400" url="" group="">
+    <Definition classid="UserCmpDefn" name="SingleMass" build="" crc="107558810" view="false" instances="0" date="1678996378" id="1780857034" w="320" h="400" url="" group="">
       <paramlist>
         <param name="Description" value="" />
       </paramlist>
@@ -54355,7 +54378,7 @@ Need to test.
         </Wire>
       </schematic>
     </Definition>
-    <Definition classid="UserCmpDefn" name="abc_dq_psid" group="" url="" version="" build="" crc="18298543" instances="0" key="" view="false" date="1677209040" id="1690178130">
+    <Definition classid="UserCmpDefn" name="abc_dq_psid" group="" url="" version="" build="" crc="18298543" instances="0" key="" view="false" date="1678996378" id="1690178130">
       <paramlist name="">
         <param name="Description" value="" />
       </paramlist>
@@ -55101,7 +55124,7 @@ Need to test.
         </Gfx>
       </graphics>
     </Definition>
-    <Definition classid="UserCmpDefn" name="dq_abc_psid" group="" url="" version="" build="" crc="79563412" instances="0" key="" view="false" date="1677209039" id="1213191902">
+    <Definition classid="UserCmpDefn" name="dq_abc_psid" group="" url="" version="" build="" crc="79563412" instances="0" key="" view="false" date="1678996378" id="1213191902">
       <paramlist name="">
         <param name="Description" value="" />
       </paramlist>
@@ -55844,7 +55867,7 @@ Need to test.
         </Gfx>
       </graphics>
     </Definition>
-    <Definition classid="UserCmpDefn" name="timestep_delay_angle" group="" url="" version="" build="" crc="66017651" instances="0" key="" view="false" date="1677209039" id="913401546">
+    <Definition classid="UserCmpDefn" name="timestep_delay_angle" group="" url="" version="" build="" crc="66017651" instances="0" key="" view="false" date="1678996377" id="913401546">
       <paramlist name="">
         <param name="Description" value="" />
       </paramlist>
@@ -56076,7 +56099,7 @@ Need to test.
         </Gfx>
       </graphics>
     </Definition>
-    <Definition classid="UserCmpDefn" name="SEXS" build="" crc="12173782" view="false" instances="0" date="1677209040" id="990107576" w="320" h="400" url="" group="">
+    <Definition classid="UserCmpDefn" name="SEXS" build="" crc="12173782" view="false" instances="0" date="1678996378" id="990107576" w="320" h="400" url="" group="">
       <paramlist>
         <param name="Description" value="" />
       </paramlist>
@@ -56736,7 +56759,7 @@ Need to test.
         </Wire>
       </schematic>
     </Definition>
-    <Definition classid="UserCmpDefn" name="PSSFixed" build="" crc="133247180" view="false" instances="0" date="1677209042" id="360526612" w="320" h="400" url="" group="">
+    <Definition classid="UserCmpDefn" name="PSSFixed" build="" crc="133247180" view="false" instances="0" date="1678996379" id="360526612" w="320" h="400" url="" group="">
       <paramlist>
         <param name="Description" value="" />
       </paramlist>
@@ -60070,7 +60093,7 @@ Need to test.
         </User>
       </schematic>
     </Definition>
-    <Definition classid="UserCmpDefn" name="SteamTurbineGov1" build="" crc="112176012" view="false" instances="0" date="1677209041" id="1132640844" w="320" h="400" url="" group="">
+    <Definition classid="UserCmpDefn" name="SteamTurbineGov1" build="" crc="96883996" view="false" instances="0" date="1678996378" id="1132640844" w="320" h="400" url="" group="">
       <paramlist>
         <param name="Description" value="" />
       </paramlist>
@@ -60431,7 +60454,7 @@ Need to test.
             <param name="Name" value="P_ref" />
           </paramlist>
         </User>
-        <User id="1153978554" classid="UserCmp" defn="master:export" x="1332" y="90" h="24" w="80" z="270" q="4" orient="2" link="-1" disable="false">
+        <User id="1153978554" classid="UserCmp" defn="master:export" x="1332" y="90" h="24" w="80" z="250" q="4" orient="2" link="-1" disable="false">
           <paramlist name="" link="-1" crc="68967217">
             <param name="Name" value="tau_m" />
           </paramlist>
@@ -60689,92 +60712,6 @@ Need to test.
             <param name="Name" value="debug1" />
           </paramlist>
         </User>
-        <User classid="UserCmp" name="master:datalabel" id="2086966281" x="864" y="396" w="48" h="23" z="1" orient="4" defn="master:datalabel" link="-1" q="4" disable="false">
-          <paramlist link="-1" name="" crc="127230955">
-            <param name="Name" value="debug1" />
-          </paramlist>
-        </User>
-        <User classid="UserCmp" id="251615959" name="master:pgb" x="864" y="396" w="59" h="40" z="260" orient="0" defn="master:pgb" link="-1" q="4" disable="false">
-          <paramlist name="" link="-1" crc="65740200">
-            <param name="Name" value="debug1" />
-            <param name="Group" value="" />
-            <param name="UseSignalName" value="1" />
-            <param name="enab" value="1" />
-            <param name="Display" value="1" />
-            <param name="Scale" value="1.0" />
-            <param name="Units" value="" />
-            <param name="mrun" value="0" />
-            <param name="Pol" value="0" />
-            <param name="Max" value="2.0" />
-            <param name="Min" value="-2.0" />
-          </paramlist>
-        </User>
-        <Frame classid="GraphFrame" id="933491522" name="frame" link="-1" x="1080" y="342" w="576" h="288">
-          <paramlist link="-1" name="">
-            <param name="Icon" value="-1,0" />
-            <param name="state" value="1" />
-            <param name="title" value="$(GROUP) : Graphs" />
-            <param name="XLabel" value="sec" />
-            <param name="Pan" value="false" />
-            <param name="pan_enable" value="false" />
-            <param name="pan_amount" value="75" />
-            <param name="markers" value="false" />
-            <param name="glyphs" value="false" />
-            <param name="ticks" value="false" />
-            <param name="grid" value="false" />
-            <param name="yinter" value="false" />
-            <param name="xinter" value="false" />
-            <param name="semilog" value="false" />
-            <param name="snapaperture" value="false" />
-            <param name="dynaperture" value="true" />
-            <param name="minorgrids" value="false" />
-            <param name="lockmarkers" value="false" />
-            <param name="deltareadout" value="false" />
-            <param name="xmarker" value="0" />
-            <param name="omarker" value="0" />
-            <param name="xfont" value="Tahoma, 12world" />
-            <param name="xangle" value="0" />
-            <param name="xtitle" value="sec" />
-            <param name="xgridauto" value="true" />
-            <param name="xgrid" value="0.1" />
-          </paramlist>
-          <paramlist name="" link="933491522">
-            <param name="xmin" value="0.000000" />
-            <param name="xmax" value="1.000000" />
-          </paramlist>
-          <Graph classid="OverlayGraph" id="1899027869" link="-1">
-            <paramlist link="-1" name="">
-              <param name="title" value="" />
-              <param name="units" value="" />
-              <param name="gridvalue" value="0.1" />
-              <param name="yintervalue" value="0" />
-              <param name="grid" value="true" />
-              <param name="ticks" value="false" />
-              <param name="glyphs" value="false" />
-              <param name="yinter" value="true" />
-              <param name="xinter" value="true" />
-              <param name="marker" value="false" />
-              <param name="trigger" value="false" />
-              <param name="invertcolor" value="false" />
-              <param name="crosshair" value="false" />
-              <param name="manualscale" value="false" />
-              <param name="autoframe" value="10" />
-              <param name="grid_color" value="#FF95908C" />
-              <param name="curve_colours" value="Navy;Green;Maroon;Teal;Purple;Brown" />
-              <param name="curve_colours2" value="Blue;Lime;Red;Aqua;Fuchsia;Yellow" />
-            </paramlist>
-            <paramlist name="" link="1899027869">
-              <param name="ymin" value="-1" />
-              <param name="ymax" value="1" />
-            </paramlist>
-            <Curve classid="Curve" id="2106466990" name="debug1" link="251615959" color="0" bold="0" show="-1" mode="0" gradient="false" transparency="255" thresh="0.5" above="High" below="Low" style="0">
-              <path />
-            </Curve>
-            <Curve classid="Curve" id="1008639123" name="tau_m" link="250107898" color="0" bold="0" show="-1" mode="0" gradient="false" transparency="255" thresh="0.5" above="High" below="Low" style="0">
-              <path />
-            </Curve>
-          </Graph>
-        </Frame>
         <User classid="UserCmp" name="master:datalabel" id="1933987607" x="864" y="486" w="24" h="23" z="1" orient="4" defn="master:datalabel" link="-1" q="4" disable="false">
           <paramlist link="-1" name="" crc="127230955">
             <param name="Name" value="tau" />
@@ -60813,38 +60750,28 @@ Need to test.
     </paramlist>
   </GlobalSubstitutions>
   <hierarchy>
-    <call link="1774770651" name="PSID_Library:Station" z="-1" view="false" instance="0">
-      <call link="1121605733" name="PSID_Library:Main" z="-1" view="false" instance="0">
+    <call link="795185137" name="PSID_Library:Station" z="-1" view="false" instance="0">
+      <call link="1121605733" name="PSID_Library:Main" z="-1" view="true" instance="0">
         <call link="590877718" name="PSID_Library:TGOV1" z="-1" view="false" instance="0" />
-        <call link="791628388" name="PSID_Library:AverageConverter" z="-1" view="false" instance="0" />
-        <call link="353908200" name="PSID_Library:FixedDCSource" z="-1" view="false" instance="0" />
-        <call link="117063645" name="PSID_Library:dq_ri" z="-1" view="false" instance="0" />
-        <call link="1536472840" name="PSID_Library:ri_dq" z="-1" view="false" instance="0" />
-        <call link="970744943" name="PSID_Library:ri_abc" z="-1" view="false" instance="0" />
-        <call link="1935923328" name="PSID_Library:VirtualInertia_ReactiveDroop" z="-1" view="false" instance="0" />
-        <call link="1711448333" name="PSID_Library:magangle_ri" z="-1" view="false" instance="0" />
-        <call link="920231050" name="PSID_Library:IEEET1" z="-1" view="false" instance="0">
-          <call link="1513031148" name="PSID_Library:exciter_saturation" z="140" view="false" instance="0" />
-          <call link="746068508" name="PSID_Library:exciter_saturation" z="360" view="false" instance="1" />
-        </call>
-        <call link="32368114" name="PSID_Library:BPA_GG" z="-1" view="false" instance="0" />
-        <call link="1257164115" name="PSID_Library:GGOV1" z="-1" view="false" instance="0">
-          <call link="471511252" name="PSID_Library:DeadBand" z="890" view="false" instance="0" />
-        </call>
         <call link="289925425" name="PSID_Library:SEXS_2" z="-1" view="false" instance="0" />
-        <call link="1584018673" name="PSID_Library:DeadBand" z="-1" view="false" instance="1" />
-        <call link="1749606776" name="PSID_Library:AVRSimple" z="-1" view="false" instance="0" />
+        <call link="1997484035" name="PSID_Library:VoltageModeControl" z="-1" view="false" instance="0" />
+        <call link="353908200" name="PSID_Library:FixedDCSource" z="-1" view="false" instance="0" />
+        <call link="1900225599" name="PSID_Library:TGTypeII" z="-1" view="false" instance="0" />
+        <call link="1935923328" name="PSID_Library:VirtualInertia_ReactiveDroop" z="-1" view="false" instance="0" />
+        <call link="1536472840" name="PSID_Library:ri_dq" z="-1" view="false" instance="0" />
+        <call link="1711448333" name="PSID_Library:magangle_ri" z="-1" view="false" instance="0" />
+        <call link="32368114" name="PSID_Library:BPA_GG" z="-1" view="false" instance="0" />
+        <call link="1584018673" name="PSID_Library:DeadBand" z="-1" view="false" instance="0" />
         <call link="1496654770" name="PSID_Library:RateLimiter" z="-1" view="false" instance="0" />
         <call link="1868501625" name="PSID_Library:FixedFrequency" z="-1" view="false" instance="0" />
-        <call link="1900225599" name="PSID_Library:TGTypeII" z="-1" view="false" instance="0" />
-        <call link="1340636822" name="PSID_Library:ActiveDroop_ReactiveDroop" z="-1" view="false" instance="0" />
         <call link="285503644" name="PSID_Library:ReducedOrderPLL" z="-1" view="false" instance="0">
           <call link="975203037" name="PSID_Library:abc_dq_psid" z="200" view="false" instance="0" />
           <call link="1708939662" name="PSID_Library:timestep_delay_angle" z="300" view="false" instance="0" />
         </call>
+        <call link="771555009" name="PSID_Library:CurrentModeControl" z="-1" view="false" instance="0" />
         <call link="1689773799" name="PSID_Library:ActivePI_ReactivePI" z="-1" view="false" instance="0" />
-        <call link="302217636" name="PSID_Library:volley_circuit_breaker_logic" z="-1" view="false" instance="0" />
         <call link="1099669844" name="PSID_Library:GAST_2" z="-1" view="false" instance="0" />
+        <call link="302217636" name="PSID_Library:volley_circuit_breaker_logic" z="-1" view="false" instance="0" />
         <call link="1093407088" name="PSID_Library:ReferenceFrameConversion_INV" z="-1" view="false" instance="0">
           <call link="1686720077" name="PSID_Library:timestep_delay_angle" z="60" view="false" instance="1" />
           <call link="1115078297" name="PSID_Library:dq_abc_psid" z="70" view="false" instance="0" />
@@ -60853,39 +60780,49 @@ Need to test.
           <call link="1142133084" name="PSID_Library:abc_dq_psid" z="100" view="false" instance="3" />
         </call>
         <call link="1585140405" name="PSID_Library:LCLFilter" z="-1" view="false" instance="0">
-          <call link="645843216" name="PSID_Library:ri_abc" z="890" view="false" instance="1" />
-        </call>
-        <call link="771555009" name="PSID_Library:CurrentModeControl" z="-1" view="false" instance="0" />
-        <call link="417400883" name="PSID_Library:SauerPaiMachine" z="-1" view="false" instance="0" />
-        <call link="1883499949" name="PSID_Library:CurrentSourceInterface" z="-1" view="false" instance="0" />
-        <call link="573480777" name="PSID_Library:exciter_saturation" z="-1" view="false" instance="2" />
-        <call link="85566424" name="PSID_Library:AVRFixed" z="-1" view="false" instance="0" />
-        <call link="457892986" name="PSID_Library:SingleMass" z="-1" view="false" instance="0" />
-        <call link="1980808861" name="PSID_Library:TGFixed" z="-1" view="false" instance="0" />
-        <call link="1518507892" name="PSID_Library:dq_abc_psid" z="-1" view="false" instance="1" />
-        <call link="691555753" name="PSID_Library:HydroTurbineGov" z="-1" view="false" instance="0" />
-        <call link="40718861" name="PSID_Library:SEXS" z="-1" view="false" instance="0" />
-        <call link="812723526" name="PSID_Library:timestep_delay_angle" z="-1" view="false" instance="2" />
-        <call link="314200446" name="PSID_Library:SteamTurbineGov1" z="-1" view="false" instance="0" />
-        <call link="1171105701" name="PSID_Library:abc_dq_psid" z="-1" view="false" instance="4" />
-        <call link="49018463" name="PSID_Library:SecOdrPole" z="-1" view="false" instance="0" />
-        <call link="1997484035" name="PSID_Library:VoltageModeControl" z="-1" view="false" instance="0" />
-        <call link="1834683724" name="PSID_Library:IEEEST" z="-1" view="false" instance="0">
-          <call link="1589910882" name="PSID_Library:SecOdrPole" z="-1" view="false" instance="1" />
-          <call link="617299442" name="PSID_Library:SecOdrPole" z="-1" view="false" instance="2" />
+          <call link="645843216" name="PSID_Library:ri_abc" z="890" view="false" instance="0" />
         </call>
         <call link="1154150259" name="PSID_Library:ReferenceFrameConversion_GEN" z="-1" view="false" instance="0">
-          <call link="1659966761" name="PSID_Library:timestep_delay_angle" z="40" view="false" instance="3" />
-          <call link="1136399958" name="PSID_Library:dq_abc_psid" z="50" view="false" instance="2" />
-          <call link="1050186494" name="PSID_Library:abc_dq_psid" z="60" view="false" instance="5" />
+          <call link="1659966761" name="PSID_Library:timestep_delay_angle" z="40" view="false" instance="2" />
+          <call link="1136399958" name="PSID_Library:dq_abc_psid" z="50" view="false" instance="1" />
+          <call link="1050186494" name="PSID_Library:abc_dq_psid" z="60" view="false" instance="4" />
         </call>
+        <call link="417400883" name="PSID_Library:SauerPaiMachine" z="-1" view="false" instance="0" />
+        <call link="1883499949" name="PSID_Library:CurrentSourceInterface" z="-1" view="false" instance="0" />
+        <call link="117063645" name="PSID_Library:dq_ri" z="-1" view="false" instance="0" />
+        <call link="1980808861" name="PSID_Library:TGFixed" z="-1" view="false" instance="0" />
+        <call link="85566424" name="PSID_Library:AVRFixed" z="-1" view="false" instance="0" />
+        <call link="1171105701" name="PSID_Library:abc_dq_psid" z="-1" view="false" instance="5" />
+        <call link="791628388" name="PSID_Library:AverageConverter" z="-1" view="false" instance="0" />
+        <call link="1518507892" name="PSID_Library:dq_abc_psid" z="-1" view="false" instance="2" />
+        <call link="457892986" name="PSID_Library:SingleMass" z="-1" view="false" instance="0" />
+        <call link="812723526" name="PSID_Library:timestep_delay_angle" z="-1" view="false" instance="3" />
         <call link="1212736682" name="PSID_Library:KauraPLL" z="-1" view="false" instance="0">
           <call link="2065055101" name="PSID_Library:timestep_delay_angle" z="330" view="false" instance="4" />
           <call link="1583651100" name="PSID_Library:abc_dq_psid" z="340" view="false" instance="6" />
         </call>
+        <call link="314200446" name="PSID_Library:SteamTurbineGov1" z="-1" view="false" instance="0" />
+        <call link="1834683724" name="PSID_Library:IEEEST" z="-1" view="false" instance="0">
+          <call link="617299442" name="PSID_Library:SecOdrPole" z="-1" view="false" instance="0" />
+          <call link="1589910882" name="PSID_Library:SecOdrPole" z="-1" view="false" instance="1" />
+        </call>
+        <call link="691555753" name="PSID_Library:HydroTurbineGov" z="-1" view="false" instance="0" />
+        <call link="789112817" name="PSID_Library:simple_brk_logic" z="-1" view="false" instance="0" />
+        <call link="1749606776" name="PSID_Library:AVRSimple" z="-1" view="false" instance="0" />
+        <call link="49018463" name="PSID_Library:SecOdrPole" z="-1" view="false" instance="2" />
+        <call link="1257164115" name="PSID_Library:GGOV1" z="-1" view="false" instance="0">
+          <call link="471511252" name="PSID_Library:DeadBand" z="890" view="false" instance="1" />
+        </call>
         <call link="1779563302" name="PSID_Library:GASTG" z="-1" view="false" instance="0" />
-        <call link="789112817" name="PSID_Library:simple_brk_logic" z="-1" view="true" instance="0" />
+        <call link="1340636822" name="PSID_Library:ActiveDroop_ReactiveDroop" z="-1" view="false" instance="0" />
+        <call link="920231050" name="PSID_Library:IEEET1" z="-1" view="false" instance="0">
+          <call link="1513031148" name="PSID_Library:exciter_saturation" z="140" view="false" instance="0" />
+          <call link="746068508" name="PSID_Library:exciter_saturation" z="360" view="false" instance="1" />
+        </call>
         <call link="1728083034" name="PSID_Library:PSSFixed" z="-1" view="false" instance="0" />
+        <call link="970744943" name="PSID_Library:ri_abc" z="-1" view="false" instance="1" />
+        <call link="40718861" name="PSID_Library:SEXS" z="-1" view="false" instance="0" />
+        <call link="573480777" name="PSID_Library:exciter_saturation" z="-1" view="false" instance="2" />
       </call>
     </call>
   </hierarchy>

--- a/_pscad_libraries/PSID_Library.psmx
+++ b/_pscad_libraries/PSID_Library.psmx
@@ -1,16 +1,75 @@
 <Meta name="PSID_Library">
-  <messagelist />
+  <messagelist>
+    <message status="warning" label="build" groupid="206502" id="2081364583" classid="CmpNavigator">
+      <User scope="PSID_Library" name="master:leadlag" status="warning" link="1721607065" /><![CDATA[Signal 'GEN' type conversion may lose accuracy at connection 'R']]></message>
+    <message status="warning" label="build" groupid="206502" id="1308125079" classid="CmpNavigator">
+      <User scope="PSID_Library" name="master:realpole" status="warning" link="506883605" /><![CDATA[Signal 'GEN' type conversion may lose accuracy at connection 'R']]></message>
+    <message status="warning" label="build" groupid="206502" id="653826552" classid="CmpNavigator">
+      <User scope="PSID_Library" name="master:realpole" status="warning" link="209374773" /><![CDATA[Signal 'GEN' type conversion may lose accuracy at connection 'R']]></message>
+    <message status="warning" label="build" groupid="206502" id="443457587" classid="CmpNavigator">
+      <User scope="PSID_Library" name="master:leadlag" status="warning" link="1283320370" /><![CDATA[Signal 'GEN' type conversion may lose accuracy at connection 'R']]></message>
+    <message status="warning" label="build" groupid="206502" id="839620547" classid="CmpNavigator">
+      <User scope="PSID_Library" name="master:integral" status="warning" link="879215536" /><![CDATA[Signal 'GEN' type conversion may lose accuracy at connection 'R']]></message>
+    <message status="warning" label="build" groupid="206502" id="1483972781" classid="CmpNavigator">
+      <User scope="PSID_Library" name="master:integral" status="warning" link="730570091" /><![CDATA[Signal 'GEN' type conversion may lose accuracy at connection 'R']]></message>
+    <message status="warning" label="build" groupid="206502" id="1565705015" classid="CmpNavigator">
+      <User scope="PSID_Library" name="master:integral" status="warning" link="2124658985" /><![CDATA[Signal 'GEN' type conversion may lose accuracy at connection 'R']]></message>
+    <message status="warning" label="build" groupid="206502" id="1846588540" classid="CmpNavigator">
+      <User scope="PSID_Library" name="master:integral" status="warning" link="1188742786" /><![CDATA[Signal 'GEN' type conversion may lose accuracy at connection 'R']]></message>
+    <message status="warning" label="build" groupid="206502" id="509400711" classid="CmpNavigator">
+      <User scope="PSID_Library" name="master:integral" status="warning" link="1096188767" /><![CDATA[Signal 'GEN' type conversion may lose accuracy at connection 'R']]></message>
+    <message status="warning" label="build" groupid="206502" id="319422051" classid="CmpNavigator">
+      <User scope="PSID_Library" name="master:integral" status="warning" link="877303017" /><![CDATA[Signal 'GEN' type conversion may lose accuracy at connection 'R']]></message>
+    <message status="warning" label="build" groupid="206502" id="231477232" classid="CmpNavigator">
+      <User scope="PSID_Library" name="master:integral" status="warning" link="1117486909" /><![CDATA[Signal 'GEN' type conversion may lose accuracy at connection 'R']]></message>
+    <message status="warning" label="build" groupid="206502" id="1868643615" classid="CmpNavigator">
+      <User scope="PSID_Library" name="master:realpole" status="warning" link="472444405" /><![CDATA[Signal 'INV' type conversion may lose accuracy at connection 'R']]></message>
+    <message status="warning" label="build" groupid="206502" id="2053261962" classid="CmpNavigator">
+      <User scope="PSID_Library" name="master:realpole" status="warning" link="440507626" /><![CDATA[Signal 'INV' type conversion may lose accuracy at connection 'R']]></message>
+    <message status="warning" label="build" groupid="206502" id="64218454" classid="CmpNavigator">
+      <User scope="PSID_Library" name="master:select" status="warning" link="1943296325" /><![CDATA[Signal 'INV' type conversion may lose accuracy at connection 'Ctrl']]></message>
+    <message status="warning" label="build" groupid="206502" id="726139773" classid="CmpNavigator">
+      <User scope="PSID_Library" name="master:integral" status="warning" link="1891684365" /><![CDATA[Signal 'INV' type conversion may lose accuracy at connection 'R']]></message>
+    <message status="warning" label="build" groupid="206502" id="1255420781" classid="CmpNavigator">
+      <User scope="PSID_Library" name="master:realpole" status="warning" link="231561493" /><![CDATA[Signal 'INV' type conversion may lose accuracy at connection 'R']]></message>
+    <message status="warning" label="build" groupid="206502" id="1354112593" classid="CmpNavigator">
+      <User scope="PSID_Library" name="master:integral" status="warning" link="1673256143" /><![CDATA[Signal 'INV' type conversion may lose accuracy at connection 'R']]></message>
+    <message status="warning" label="build" groupid="206502" id="576028110" classid="CmpNavigator">
+      <User scope="PSID_Library" name="master:realpole" status="warning" link="393200150" /><![CDATA[Signal 'INV' type conversion may lose accuracy at connection 'R']]></message>
+    <message status="warning" label="build" groupid="206502" id="864167729" classid="CmpNavigator">
+      <User scope="PSID_Library" name="master:integral" status="warning" link="496252468" /><![CDATA[Signal 'INV' type conversion may lose accuracy at connection 'R']]></message>
+    <message status="warning" label="build" groupid="206502" id="615943853" classid="CmpNavigator">
+      <User scope="PSID_Library" name="master:integral" status="warning" link="1332369744" /><![CDATA[Signal 'INV' type conversion may lose accuracy at connection 'R']]></message>
+    <message status="warning" label="build" groupid="206502" id="1531892592" classid="CmpNavigator">
+      <User scope="PSID_Library" name="master:realpole" status="warning" link="1188308993" /><![CDATA[Signal 'INV' type conversion may lose accuracy at connection 'R']]></message>
+    <message status="warning" label="build" groupid="206502" id="98313071" classid="CmpNavigator">
+      <User scope="PSID_Library" name="master:realpole" status="warning" link="513146012" /><![CDATA[Signal 'INV' type conversion may lose accuracy at connection 'R']]></message>
+    <message status="warning" label="build" groupid="206502" id="790114751" classid="CmpNavigator">
+      <User scope="PSID_Library" name="master:integral" status="warning" link="926160967" /><![CDATA[Signal 'INV' type conversion may lose accuracy at connection 'R']]></message>
+    <message status="warning" label="build" groupid="206502" id="704465913" classid="CmpNavigator">
+      <User scope="PSID_Library" name="master:realpole" status="warning" link="1499652905" /><![CDATA[Signal 'INV' type conversion may lose accuracy at connection 'R']]></message>
+    <message status="warning" label="build" groupid="206502" id="1693334531" classid="CmpNavigator">
+      <User scope="PSID_Library" name="master:realpole" status="warning" link="13584325" /><![CDATA[Signal 'INV' type conversion may lose accuracy at connection 'R']]></message>
+    <message status="warning" label="build" groupid="206502" id="1579306147" classid="CmpNavigator">
+      <User scope="PSID_Library" name="master:integral" status="warning" link="2071166572" /><![CDATA[Signal 'INV' type conversion may lose accuracy at connection 'R']]></message>
+    <message status="warning" label="build" groupid="206502" id="306083339" classid="CmpNavigator">
+      <User scope="PSID_Library" name="master:integral" status="warning" link="1544546380" /><![CDATA[Signal 'INV' type conversion may lose accuracy at connection 'R']]></message>
+    <message status="warning" label="build" groupid="206502" id="126842897" classid="CmpNavigator">
+      <User scope="PSID_Library" name="master:integral" status="warning" link="1271894104" /><![CDATA[Signal 'INV' type conversion may lose accuracy at connection 'R']]></message>
+    <message status="warning" label="build" groupid="206502" id="621347892" classid="CmpNavigator">
+      <User scope="PSID_Library" name="master:integral" status="warning" link="138022980" /><![CDATA[Signal 'INV' type conversion may lose accuracy at connection 'R']]></message>
+  </messagelist>
   <List classid="Settings" />
   <ViewContext>
-    <Window defn="PSID_Library:simple_brk_logic" call="0" />
+    <Window defn="PSID_Library:Main" call="0" />
   </ViewContext>
   <List classid="View">
-    <View name="Main" zoomlevel="4" scrollx="5212" scrolly="1994" zoomscale="2.92969" />
+    <View name="Main" zoomlevel="4" scrollx="794" scrolly="562" zoomscale="0.960001" />
     <View name="TGTypeII" zoomlevel="4" scrollx="0" scrolly="252" zoomscale="0.96" />
     <View name="TGOV1" zoomlevel="4" scrollx="184" scrolly="185" zoomscale="1.5" />
     <View name="SEXS" zoomlevel="1" scrollx="0" scrolly="0" zoomscale="1.5" />
     <View name="CurrentControl" zoomlevel="3" scrollx="0" scrolly="0" />
-    <View name="KauraPLL" zoomlevel="5" scrollx="235" scrolly="0" zoomscale="0.96" />
+    <View name="KauraPLL" zoomlevel="5" scrollx="0" scrolly="0" zoomscale="0.49152" />
     <View name="AverageConverter" zoomlevel="6" scrollx="0" scrolly="0" zoomscale="0.768" />
     <View name="FixedDCSource" zoomlevel="4" scrollx="0" scrolly="0" zoomscale="0.768" />
     <View name="OuterControl_1" zoomlevel="4" scrollx="0" scrolly="11" />
@@ -30,7 +89,7 @@
     <View name="VoltageModeControl" zoomlevel="4" scrollx="50" scrolly="90" zoomscale="0.96" />
     <View name="FixedFrequency" zoomlevel="4" scrollx="0" scrolly="0" zoomscale="0.96" />
     <View name="VirtualInertia_ReactiveDroop" zoomlevel="4" scrollx="0" scrolly="0" zoomscale="0.768" />
-    <View name="ActiveDroop_ReactiveDroop" zoomlevel="3" scrollx="189" scrolly="0" zoomscale="0.96" />
+    <View name="ActiveDroop_ReactiveDroop" zoomlevel="3" scrollx="23" scrolly="23" zoomscale="0.49152" />
     <View name="ReducedOrderPLL" zoomlevel="4" scrollx="0" scrolly="0" zoomscale="0.96" />
     <View name="CurrentModeControl" zoomlevel="5" scrollx="0" scrolly="0" zoomscale="0.768" />
     <View name="ActivePI_ReactivePI" zoomlevel="6" scrollx="62" scrolly="138" zoomscale="0.96" />

--- a/_pscad_libraries/PSID_Library_Inverters.bakx
+++ b/_pscad_libraries/PSID_Library_Inverters.bakx
@@ -21,7 +21,7 @@
     <param name="Warn" value="0" />
     <param name="Check" value="0" />
     <param name="description" value="" />
-    <param name="revisor" value="Matt Bossart, 1677207820" />
+    <param name="revisor" value="Matt Bossart, 1677683284" />
     <param name="sparsity_threshold" value="200" />
   </paramlist>
   <Layers>
@@ -29798,7 +29798,7 @@
         </Gfx>
       </graphics>
     </Definition>
-    <Definition classid="UserCmpDefn" name="DROOP_GFM" group="" url="" version="" build="" crc="67376769" instances="0" key="" view="false" date="1671120175" id="744715342">
+    <Definition classid="UserCmpDefn" name="DROOP_GFM" group="" url="" version="" build="" crc="67376769" instances="0" key="" view="false" date="1677209048" id="744715342">
       <paramlist name="">
         <param name="Description" value="" />
       </paramlist>
@@ -32709,7 +32709,7 @@
         <grouping />
       </schematic>
     </Definition>
-    <Definition classid="UserCmpDefn" name="Main" id="1668162628" group="" url="" version="" build="" crc="22609555" view="false" date="0">
+    <Definition classid="UserCmpDefn" name="Main" id="1668162628" group="" url="" version="" build="" crc="120648248" view="false" date="0">
       <paramlist name="">
         <param name="Description" value="" />
       </paramlist>
@@ -33423,7 +33423,7 @@
             <param name="f_out" value="Freq_out" />
           </paramlist>
         </User>
-        <User classid="UserCmp" id="750910413" name="PSID_Library_Inverters:SAUERPAI_SEXS_GASTG_IEEEST" x="396" y="234" w="118" h="78" z="-1" orient="0" defn="PSID_Library_Inverters:SAUERPAI_SEXS_GASTG_IEEEST" link="-1" q="4" disable="false">
+        <User classid="UserCmp" id="750910413" name="PSID_Library_Inverters:SAUERPAI_SEXS_GASTG_IEEEST" x="396" y="234" w="119" h="78" z="-1" orient="0" defn="PSID_Library_Inverters:SAUERPAI_SEXS_GASTG_IEEEST" link="-1" q="4" disable="false">
           <paramlist name="" link="-1" crc="18129811">
             <param name="Name" value="" />
             <param name="f_base" value="60" />
@@ -33573,7 +33573,7 @@
             <param name="primemover_x0_3" value="0" />
           </paramlist>
         </User>
-        <User classid="UserCmp" id="798203330" name="PSID_Library_Inverters:SAUERPAI_SEXS_GASTG_PSSFIXED" x="396" y="324" w="118" h="78" z="-1" orient="0" defn="PSID_Library_Inverters:SAUERPAI_SEXS_GASTG_PSSFIXED" link="-1" q="4" disable="false">
+        <User classid="UserCmp" id="798203330" name="PSID_Library_Inverters:SAUERPAI_SEXS_GASTG_PSSFIXED" x="396" y="324" w="119" h="78" z="-1" orient="0" defn="PSID_Library_Inverters:SAUERPAI_SEXS_GASTG_PSSFIXED" link="-1" q="4" disable="false">
           <paramlist name="" link="-1" crc="111202234">
             <param name="Name" value="" />
             <param name="f_base" value="60" />
@@ -33694,7 +33694,7 @@
             <param name="primemover_D_turb" value="0" />
           </paramlist>
         </User>
-        <User classid="UserCmp" id="108144603" name="PSID_Library_Inverters:SAUERPAI_SEXS_HYGOV_IEEEST" x="522" y="234" w="118" h="78" z="-1" orient="0" defn="PSID_Library_Inverters:SAUERPAI_SEXS_HYGOV_IEEEST" link="-1" q="4" disable="false">
+        <User classid="UserCmp" id="108144603" name="PSID_Library_Inverters:SAUERPAI_SEXS_HYGOV_IEEEST" x="522" y="234" w="119" h="78" z="-1" orient="0" defn="PSID_Library_Inverters:SAUERPAI_SEXS_HYGOV_IEEEST" link="-1" q="4" disable="false">
           <paramlist name="" link="-1" crc="107858088">
             <param name="Name" value="" />
             <param name="f_base" value="60" />
@@ -33847,7 +33847,7 @@
             <param name="primemover_q_nl" value="0" />
           </paramlist>
         </User>
-        <User classid="UserCmp" id="1980245536" name="PSID_Library_Inverters:SAUERPAI_SEXS_HYGOV_PSSFIXED" x="522" y="324" w="118" h="78" z="-1" orient="0" defn="PSID_Library_Inverters:SAUERPAI_SEXS_HYGOV_PSSFIXED" link="-1" q="4" disable="false">
+        <User classid="UserCmp" id="1980245536" name="PSID_Library_Inverters:SAUERPAI_SEXS_HYGOV_PSSFIXED" x="522" y="324" w="119" h="78" z="-1" orient="0" defn="PSID_Library_Inverters:SAUERPAI_SEXS_HYGOV_PSSFIXED" link="-1" q="4" disable="false">
           <paramlist name="" link="-1" crc="109936304">
             <param name="Name" value="" />
             <param name="f_base" value="60" />
@@ -33962,7 +33962,7 @@
             <param name="primemover_q_nl" value="0" />
           </paramlist>
         </User>
-        <User classid="UserCmp" id="1213387110" name="PSID_Library_Inverters:SAUERPAI_SEXS_TGOV1_IEEEST" x="720" y="234" w="118" h="78" z="-1" orient="0" defn="PSID_Library_Inverters:SAUERPAI_SEXS_TGOV1_IEEEST" link="-1" q="4" disable="false">
+        <User classid="UserCmp" id="1213387110" name="PSID_Library_Inverters:SAUERPAI_SEXS_TGOV1_IEEEST" x="720" y="234" w="119" h="78" z="-1" orient="0" defn="PSID_Library_Inverters:SAUERPAI_SEXS_TGOV1_IEEEST" link="-1" q="4" disable="false">
           <paramlist name="" link="-1" crc="126701363">
             <param name="Name" value="" />
             <param name="f_base" value="60" />
@@ -34105,7 +34105,7 @@
             <param name="pss_Vcl" value="0" />
           </paramlist>
         </User>
-        <User classid="UserCmp" id="1765688990" name="PSID_Library_Inverters:SAUERPAI_SEXS_TGOV1_PSSFIXED" x="720" y="324" w="118" h="78" z="-1" orient="0" defn="PSID_Library_Inverters:SAUERPAI_SEXS_TGOV1_PSSFIXED" link="-1" q="4" disable="false">
+        <User classid="UserCmp" id="1765688990" name="PSID_Library_Inverters:SAUERPAI_SEXS_TGOV1_PSSFIXED" x="720" y="324" w="119" h="78" z="-1" orient="0" defn="PSID_Library_Inverters:SAUERPAI_SEXS_TGOV1_PSSFIXED" link="-1" q="4" disable="false">
           <paramlist name="" link="-1" crc="104761221">
             <param name="Name" value="" />
             <param name="f_base" value="60" />
@@ -48600,7 +48600,7 @@ https://www.phasetophase.nl/pdf/SynchronousMachineTurbineGoverningSystems.pdf]]>
         </Gfx>
       </graphics>
     </Definition>
-    <Definition classid="UserCmpDefn" name="SAUERPAI_SEXS_TGOV1_PSSFIXED" group="" url="" version="" build="" crc="90769185" instances="0" key="" view="false" date="1671135956" id="887792995">
+    <Definition classid="UserCmpDefn" name="SAUERPAI_SEXS_TGOV1_PSSFIXED" group="" url="" version="" build="" crc="90769185" instances="0" key="" view="false" date="1677209038" id="887792995">
       <paramlist name="">
         <param name="Description" value="" />
       </paramlist>
@@ -49826,7 +49826,7 @@ https://www.phasetophase.nl/pdf/SynchronousMachineTurbineGoverningSystems.pdf]]>
         </Gfx>
       </graphics>
     </Definition>
-    <Definition classid="UserCmpDefn" name="GFL_KAURA_PLL" group="" url="" version="" build="" crc="26340565" instances="0" key="" view="false" date="1671135954" id="1255707902">
+    <Definition classid="UserCmpDefn" name="GFL_KAURA_PLL" group="" url="" version="" build="" crc="85570781" instances="0" key="" view="false" date="1671135954" id="1255707902">
       <paramlist name="">
         <param name="Description" value="" />
       </paramlist>
@@ -50189,17 +50189,17 @@ https://www.phasetophase.nl/pdf/SynchronousMachineTurbineGoverningSystems.pdf]]>
           <param name="virtual_filter" value="" />
           <param name="animation_freq" value="500" />
         </paramlist>
-        <User classid="UserCmp" name="master:export" id="802856412" x="918" y="126" w="80" h="24" z="560" orient="4" defn="master:export" link="-1" q="4" disable="false">
+        <User classid="UserCmp" name="master:export" id="802856412" x="918" y="126" w="80" h="24" z="570" orient="4" defn="master:export" link="-1" q="4" disable="false">
           <paramlist link="-1" name="" crc="68967217">
             <param name="Name" value="Q_out" />
           </paramlist>
         </User>
-        <User classid="UserCmp" name="master:export" id="128239133" x="918" y="108" w="78" h="24" z="570" orient="4" defn="master:export" link="-1" q="4" disable="false">
+        <User classid="UserCmp" name="master:export" id="128239133" x="918" y="108" w="78" h="24" z="580" orient="4" defn="master:export" link="-1" q="4" disable="false">
           <paramlist link="-1" name="" crc="68967217">
             <param name="Name" value="P_out" />
           </paramlist>
         </User>
-        <User classid="UserCmp" name="master:export" id="47356536" x="918" y="144" w="75" h="24" z="550" orient="4" defn="master:export" link="-1" q="4" disable="false">
+        <User classid="UserCmp" name="master:export" id="47356536" x="918" y="144" w="75" h="24" z="560" orient="4" defn="master:export" link="-1" q="4" disable="false">
           <paramlist link="-1" name="" crc="68967217">
             <param name="Name" value="f_out" />
           </paramlist>
@@ -50210,7 +50210,7 @@ https://www.phasetophase.nl/pdf/SynchronousMachineTurbineGoverningSystems.pdf]]>
             <param name="AL2" value="" />
           </paramlist>
         </User>
-        <User classid="UserCmp" name="PSID_Library:AverageConverter" id="2046628562" x="468" y="360" w="133" h="80" z="540" orient="0" defn="PSID_Library:AverageConverter" link="-1" q="4" disable="false">
+        <User classid="UserCmp" name="PSID_Library:AverageConverter" id="2046628562" x="468" y="360" w="133" h="80" z="550" orient="0" defn="PSID_Library:AverageConverter" link="-1" q="4" disable="false">
           <paramlist link="-1" name="" crc="85637438">
             <param name="Name" value="" />
           </paramlist>
@@ -50245,7 +50245,7 @@ https://www.phasetophase.nl/pdf/SynchronousMachineTurbineGoverningSystems.pdf]]>
             <param name="Name" value="S_base" />
           </paramlist>
         </User>
-        <User classid="UserCmp" name="PSID_Library:FixedDCSource" id="539411229" x="612" y="342" w="146" h="80" z="480" orient="0" defn="PSID_Library:FixedDCSource" link="-1" q="4" disable="false">
+        <User classid="UserCmp" name="PSID_Library:FixedDCSource" id="539411229" x="612" y="342" w="146" h="80" z="490" orient="0" defn="PSID_Library:FixedDCSource" link="-1" q="4" disable="false">
           <paramlist link="-1" name="" crc="44713234">
             <param name="Name" value="" />
             <param name="voltage" value="voltage" />
@@ -50446,7 +50446,7 @@ https://www.phasetophase.nl/pdf/SynchronousMachineTurbineGoverningSystems.pdf]]>
             <param name="Name" value="outercontrol_x0_1" />
           </paramlist>
         </User>
-        <User classid="UserCmp" name="PSID_Library:ActivePI_ReactivePI" id="1168180068" x="486" y="504" w="233" h="116" z="520" orient="0" defn="PSID_Library:ActivePI_ReactivePI" link="-1" q="4" disable="false">
+        <User classid="UserCmp" name="PSID_Library:ActivePI_ReactivePI" id="1168180068" x="486" y="504" w="233" h="116" z="530" orient="0" defn="PSID_Library:ActivePI_ReactivePI" link="-1" q="4" disable="false">
           <paramlist link="-1" name="" crc="85039597">
             <param name="Name" value="" />
             <param name="kq" value="kq" />
@@ -50503,7 +50503,7 @@ https://www.phasetophase.nl/pdf/SynchronousMachineTurbineGoverningSystems.pdf]]>
             <param name="ymax" value="1" />
           </paramlist>
         </User>
-        <User classid="UserCmp" name="PSID_Library:CurrentModeControl" id="2075316472" x="450" y="396" w="133" h="116" z="530" orient="0" defn="PSID_Library:CurrentModeControl" link="-1" q="4" disable="false">
+        <User classid="UserCmp" name="PSID_Library:CurrentModeControl" id="2075316472" x="450" y="396" w="133" h="116" z="540" orient="0" defn="PSID_Library:CurrentModeControl" link="-1" q="4" disable="false">
           <paramlist link="-1" name="" crc="75012887">
             <param name="Name" value="" />
             <param name="kpv" value="kpv" />
@@ -51079,7 +51079,7 @@ https://www.phasetophase.nl/pdf/SynchronousMachineTurbineGoverningSystems.pdf]]>
           <vertex x="0" y="0" />
           <vertex x="0" y="90" />
         </Wire>
-        <User classid="UserCmp" id="1559633434" name="PSID_Library:LCLFilter" x="486" y="72" w="205" h="92" z="500" orient="0" defn="PSID_Library:LCLFilter" link="-1" q="4" disable="false">
+        <User classid="UserCmp" id="1559633434" name="PSID_Library:LCLFilter" x="486" y="72" w="205" h="92" z="510" orient="0" defn="PSID_Library:LCLFilter" link="-1" q="4" disable="false">
           <paramlist name="" link="-1" crc="57376948">
             <param name="Name" value="" />
             <param name="Name_0" value="" />
@@ -51102,12 +51102,12 @@ https://www.phasetophase.nl/pdf/SynchronousMachineTurbineGoverningSystems.pdf]]>
             <param name="x0_6" value="filter_x0_6" />
           </paramlist>
         </User>
-        <User classid="UserCmp" id="817365154" name="PSID_Library:ReferenceFrameConversion_INV" x="486" y="198" w="250" h="81" z="490" orient="0" defn="PSID_Library:ReferenceFrameConversion_INV" link="-1" q="4" disable="false">
+        <User classid="UserCmp" id="817365154" name="PSID_Library:ReferenceFrameConversion_INV" x="486" y="198" w="250" h="81" z="500" orient="0" defn="PSID_Library:ReferenceFrameConversion_INV" link="-1" q="4" disable="false">
           <paramlist name="" link="-1" crc="28307411">
             <param name="Name" value="" />
           </paramlist>
         </User>
-        <User classid="UserCmp" name="PSID_Library:KauraPLL" id="1462166105" x="468" y="522" w="164" h="61" z="-1" orient="0" defn="PSID_Library:KauraPLL" link="-1" q="4" disable="false">
+        <User classid="UserCmp" name="PSID_Library:KauraPLL" id="1462166105" x="468" y="522" w="164" h="61" z="520" orient="0" defn="PSID_Library:KauraPLL" link="-1" q="4" disable="false">
           <paramlist link="-1" name="" crc="115842699">
             <param name="Name" value="" />
             <param name="w_lp" value="500.0" />
@@ -51120,41 +51120,41 @@ https://www.phasetophase.nl/pdf/SynchronousMachineTurbineGoverningSystems.pdf]]>
             <param name="x0_4" value="freqestimator_x0_4" />
             <param name="f_base" value="f_base" />
             <param name="InitGv" value="INV" />
-            <param name="INV" value="InitGv" />
+            <param name="INV" value="INV" />
             <param name="t_INV" value="0" />
           </paramlist>
         </User>
-        <User classid="UserCmp" name="master:import" id="23328345" x="144" y="1170" w="154" h="25" z="510" orient="0" defn="master:import" link="-1" q="4" disable="false">
+        <User classid="UserCmp" name="master:import" id="23328345" x="144" y="1170" w="154" h="25" z="420" orient="0" defn="master:import" link="-1" q="4" disable="false">
           <paramlist link="-1" name="" crc="117509081">
             <param name="Name" value="freqestimator_x0_1" />
           </paramlist>
         </User>
-        <User classid="UserCmp" name="master:import" id="1639505460" x="144" y="1188" w="154" h="25" z="530" orient="0" defn="master:import" link="-1" q="4" disable="false">
+        <User classid="UserCmp" name="master:import" id="1639505460" x="144" y="1188" w="154" h="25" z="440" orient="0" defn="master:import" link="-1" q="4" disable="false">
           <paramlist link="-1" name="" crc="117509081">
             <param name="Name" value="freqestimator_x0_2" />
           </paramlist>
         </User>
-        <User classid="UserCmp" name="master:import" id="1326944599" x="144" y="1206" w="154" h="25" z="550" orient="0" defn="master:import" link="-1" q="4" disable="false">
+        <User classid="UserCmp" name="master:import" id="1326944599" x="144" y="1206" w="154" h="25" z="460" orient="0" defn="master:import" link="-1" q="4" disable="false">
           <paramlist link="-1" name="" crc="117509081">
             <param name="Name" value="freqestimator_x0_3" />
           </paramlist>
         </User>
-        <User classid="UserCmp" name="master:import" id="849913571" x="144" y="1224" w="154" h="25" z="570" orient="0" defn="master:import" link="-1" q="4" disable="false">
+        <User classid="UserCmp" name="master:import" id="849913571" x="144" y="1224" w="154" h="25" z="480" orient="0" defn="master:import" link="-1" q="4" disable="false">
           <paramlist link="-1" name="" crc="117509081">
             <param name="Name" value="freqestimator_x0_4" />
           </paramlist>
         </User>
-        <User classid="UserCmp" name="master:import" id="1257884465" x="270" y="1170" w="100" h="25" z="520" orient="0" defn="master:import" link="-1" q="4" disable="false">
+        <User classid="UserCmp" name="master:import" id="1257884465" x="270" y="1170" w="100" h="25" z="430" orient="0" defn="master:import" link="-1" q="4" disable="false">
           <paramlist link="-1" name="" crc="117509081">
             <param name="Name" value="omega_lp" />
           </paramlist>
         </User>
-        <User classid="UserCmp" name="master:import" id="1501993852" x="270" y="1188" w="78" h="25" z="540" orient="0" defn="master:import" link="-1" q="4" disable="false">
+        <User classid="UserCmp" name="master:import" id="1501993852" x="270" y="1188" w="78" h="25" z="450" orient="0" defn="master:import" link="-1" q="4" disable="false">
           <paramlist link="-1" name="" crc="117509081">
             <param name="Name" value="kp_pll" />
           </paramlist>
         </User>
-        <User classid="UserCmp" name="master:import" id="470940695" x="270" y="1206" w="73" h="25" z="560" orient="0" defn="master:import" link="-1" q="4" disable="false">
+        <User classid="UserCmp" name="master:import" id="470940695" x="270" y="1206" w="73" h="25" z="470" orient="0" defn="master:import" link="-1" q="4" disable="false">
           <paramlist link="-1" name="" crc="117509081">
             <param name="Name" value="ki_pll" />
           </paramlist>
@@ -51299,189 +51299,190 @@ https://www.phasetophase.nl/pdf/SynchronousMachineTurbineGoverningSystems.pdf]]>
     </paramlist>
   </GlobalSubstitutions>
   <hierarchy>
-    <call link="397259982" name="PSID_Library_Inverters:Station" z="-1" view="false" instance="0">
+    <call link="52356596" name="PSID_Library_Inverters:Station" z="-1" view="false" instance="0">
       <call link="223495102" name="PSID_Library_Inverters:Main" z="-1" view="false" instance="0">
-        <call link="621267136" name="PSID_Library_Inverters:GFL_KAURA_PLL" z="-1" view="true" instance="0">
-          <call link="1462166105" name="PSID_Library:KauraPLL" z="-1" view="false" instance="0">
-            <call link="2065055101" name="PSID_Library:timestep_delay_angle" z="330" view="false" instance="0" />
-            <call link="1583651100" name="PSID_Library:abc_dq_psid" z="340" view="false" instance="0" />
-          </call>
-          <call link="539411229" name="PSID_Library:FixedDCSource" z="480" view="false" instance="0" />
-          <call link="817365154" name="PSID_Library:ReferenceFrameConversion_INV" z="490" view="false" instance="0">
-            <call link="1686720077" name="PSID_Library:timestep_delay_angle" z="60" view="false" instance="1" />
+        <call link="238600983" name="PSID_Library_Inverters:DARCO_VSM" z="-1" view="false" instance="0">
+          <call link="537476440" name="PSID_Library:ReferenceFrameConversion_INV" z="580" view="false" instance="0">
+            <call link="1686720077" name="PSID_Library:timestep_delay_angle" z="60" view="false" instance="0" />
             <call link="1115078297" name="PSID_Library:dq_abc_psid" z="70" view="false" instance="0" />
-            <call link="1416558759" name="PSID_Library:abc_dq_psid" z="80" view="false" instance="1" />
-            <call link="294237646" name="PSID_Library:abc_dq_psid" z="90" view="false" instance="2" />
-            <call link="1142133084" name="PSID_Library:abc_dq_psid" z="100" view="false" instance="3" />
+            <call link="1416558759" name="PSID_Library:abc_dq_psid" z="80" view="false" instance="0" />
+            <call link="294237646" name="PSID_Library:abc_dq_psid" z="90" view="false" instance="1" />
+            <call link="1142133084" name="PSID_Library:abc_dq_psid" z="100" view="false" instance="2" />
           </call>
-          <call link="1559633434" name="PSID_Library:LCLFilter" z="500" view="false" instance="0">
+          <call link="1674048550" name="PSID_Library:LCLFilter" z="590" view="false" instance="0">
             <call link="645843216" name="PSID_Library:ri_abc" z="890" view="false" instance="0" />
           </call>
-          <call link="1168180068" name="PSID_Library:ActivePI_ReactivePI" z="520" view="false" instance="0" />
-          <call link="2075316472" name="PSID_Library:CurrentModeControl" z="530" view="false" instance="0" />
-          <call link="2046628562" name="PSID_Library:AverageConverter" z="540" view="false" instance="0" />
+          <call link="356470831" name="PSID_Library:KauraPLL" z="600" view="false" instance="0">
+            <call link="2065055101" name="PSID_Library:timestep_delay_angle" z="330" view="false" instance="1" />
+            <call link="1583651100" name="PSID_Library:abc_dq_psid" z="340" view="false" instance="3" />
+          </call>
+          <call link="157850209" name="PSID_Library:VirtualInertia_ReactiveDroop" z="610" view="false" instance="0" />
+          <call link="645732161" name="PSID_Library:VoltageModeControl" z="620" view="false" instance="0" />
+          <call link="1730679757" name="PSID_Library:FixedDCSource" z="630" view="false" instance="0" />
+          <call link="764540826" name="PSID_Library:AverageConverter" z="640" view="false" instance="0" />
         </call>
-        <call link="238600983" name="PSID_Library_Inverters:DARCO_VSM" z="-1" view="false" instance="0">
-          <call link="537476440" name="PSID_Library:ReferenceFrameConversion_INV" z="580" view="false" instance="1">
+        <call link="461198950" name="PSID_Library_Inverters:DROOP_GFM" z="-1" view="false" instance="0">
+          <call link="219331248" name="PSID_Library:FixedDCSource" z="500" view="false" instance="1" />
+          <call link="1660439571" name="PSID_Library:ReferenceFrameConversion_INV" z="510" view="false" instance="1">
             <call link="1686720077" name="PSID_Library:timestep_delay_angle" z="60" view="false" instance="2" />
             <call link="1115078297" name="PSID_Library:dq_abc_psid" z="70" view="false" instance="1" />
             <call link="1416558759" name="PSID_Library:abc_dq_psid" z="80" view="false" instance="4" />
             <call link="294237646" name="PSID_Library:abc_dq_psid" z="90" view="false" instance="5" />
             <call link="1142133084" name="PSID_Library:abc_dq_psid" z="100" view="false" instance="6" />
           </call>
-          <call link="1674048550" name="PSID_Library:LCLFilter" z="590" view="false" instance="1">
+          <call link="1670526590" name="PSID_Library:LCLFilter" z="520" view="false" instance="1">
             <call link="645843216" name="PSID_Library:ri_abc" z="890" view="false" instance="1" />
-          </call>
-          <call link="356470831" name="PSID_Library:KauraPLL" z="600" view="false" instance="1">
-            <call link="2065055101" name="PSID_Library:timestep_delay_angle" z="330" view="false" instance="3" />
-            <call link="1583651100" name="PSID_Library:abc_dq_psid" z="340" view="false" instance="7" />
-          </call>
-          <call link="157850209" name="PSID_Library:VirtualInertia_ReactiveDroop" z="610" view="false" instance="0" />
-          <call link="645732161" name="PSID_Library:VoltageModeControl" z="620" view="false" instance="0" />
-          <call link="1730679757" name="PSID_Library:FixedDCSource" z="630" view="false" instance="1" />
-          <call link="764540826" name="PSID_Library:AverageConverter" z="640" view="false" instance="1" />
-        </call>
-        <call link="461198950" name="PSID_Library_Inverters:DROOP_GFM" z="-1" view="false" instance="0">
-          <call link="219331248" name="PSID_Library:FixedDCSource" z="500" view="false" instance="2" />
-          <call link="1660439571" name="PSID_Library:ReferenceFrameConversion_INV" z="510" view="false" instance="2">
-            <call link="1686720077" name="PSID_Library:timestep_delay_angle" z="60" view="false" instance="4" />
-            <call link="1115078297" name="PSID_Library:dq_abc_psid" z="70" view="false" instance="2" />
-            <call link="1416558759" name="PSID_Library:abc_dq_psid" z="80" view="false" instance="8" />
-            <call link="294237646" name="PSID_Library:abc_dq_psid" z="90" view="false" instance="9" />
-            <call link="1142133084" name="PSID_Library:abc_dq_psid" z="100" view="false" instance="10" />
-          </call>
-          <call link="1670526590" name="PSID_Library:LCLFilter" z="520" view="false" instance="2">
-            <call link="645843216" name="PSID_Library:ri_abc" z="890" view="false" instance="2" />
           </call>
           <call link="822903436" name="PSID_Library:FixedFrequency" z="530" view="false" instance="0" />
           <call link="966491600" name="PSID_Library:ActiveDroop_ReactiveDroop" z="540" view="false" instance="0" />
           <call link="2079101627" name="PSID_Library:VoltageModeControl" z="550" view="false" instance="1" />
-          <call link="2040622412" name="PSID_Library:AverageConverter" z="560" view="false" instance="2" />
+          <call link="2040622412" name="PSID_Library:AverageConverter" z="560" view="false" instance="1" />
         </call>
         <call link="439422545" name="PSID_Library_Inverters:GFL_REDUCED_PLL" z="-1" view="false" instance="0">
-          <call link="1760640988" name="PSID_Library:FixedDCSource" z="480" view="false" instance="3" />
-          <call link="1229355875" name="PSID_Library:ReferenceFrameConversion_INV" z="490" view="false" instance="3">
-            <call link="1686720077" name="PSID_Library:timestep_delay_angle" z="60" view="false" instance="5" />
-            <call link="1115078297" name="PSID_Library:dq_abc_psid" z="70" view="false" instance="3" />
-            <call link="1416558759" name="PSID_Library:abc_dq_psid" z="80" view="false" instance="11" />
-            <call link="294237646" name="PSID_Library:abc_dq_psid" z="90" view="false" instance="12" />
-            <call link="1142133084" name="PSID_Library:abc_dq_psid" z="100" view="false" instance="13" />
+          <call link="1760640988" name="PSID_Library:FixedDCSource" z="480" view="false" instance="2" />
+          <call link="1229355875" name="PSID_Library:ReferenceFrameConversion_INV" z="490" view="false" instance="2">
+            <call link="1686720077" name="PSID_Library:timestep_delay_angle" z="60" view="false" instance="3" />
+            <call link="1115078297" name="PSID_Library:dq_abc_psid" z="70" view="false" instance="2" />
+            <call link="1416558759" name="PSID_Library:abc_dq_psid" z="80" view="false" instance="7" />
+            <call link="294237646" name="PSID_Library:abc_dq_psid" z="90" view="false" instance="8" />
+            <call link="1142133084" name="PSID_Library:abc_dq_psid" z="100" view="false" instance="9" />
           </call>
-          <call link="1822229676" name="PSID_Library:LCLFilter" z="500" view="false" instance="3">
-            <call link="645843216" name="PSID_Library:ri_abc" z="890" view="false" instance="3" />
+          <call link="1822229676" name="PSID_Library:LCLFilter" z="500" view="false" instance="2">
+            <call link="645843216" name="PSID_Library:ri_abc" z="890" view="false" instance="2" />
           </call>
           <call link="1494865977" name="PSID_Library:ReducedOrderPLL" z="510" view="false" instance="0">
-            <call link="975203037" name="PSID_Library:abc_dq_psid" z="200" view="false" instance="14" />
-            <call link="1708939662" name="PSID_Library:timestep_delay_angle" z="300" view="false" instance="6" />
+            <call link="975203037" name="PSID_Library:abc_dq_psid" z="200" view="false" instance="10" />
+            <call link="1708939662" name="PSID_Library:timestep_delay_angle" z="300" view="false" instance="4" />
           </call>
-          <call link="815459201" name="PSID_Library:ActivePI_ReactivePI" z="520" view="false" instance="1" />
-          <call link="2051780060" name="PSID_Library:CurrentModeControl" z="530" view="false" instance="1" />
-          <call link="784303139" name="PSID_Library:AverageConverter" z="540" view="false" instance="3" />
+          <call link="815459201" name="PSID_Library:ActivePI_ReactivePI" z="520" view="false" instance="0" />
+          <call link="2051780060" name="PSID_Library:CurrentModeControl" z="530" view="false" instance="0" />
+          <call link="784303139" name="PSID_Library:AverageConverter" z="540" view="false" instance="2" />
         </call>
-        <call link="408889240" name="PSID_Library_Inverters:DEMETRIOUS_SC" z="-1" view="false" instance="0">
-          <call link="1253756838" name="PSID_Library:IEEET1" z="460" view="false" instance="0">
+        <call link="788221067" name="PSID_Library_Inverters:DEMETRIOUS_SG" z="-1" view="false" instance="0">
+          <call link="13104666" name="PSID_Library:BPA_GG" z="540" view="false" instance="0" />
+          <call link="1559344279" name="PSID_Library:IEEET1" z="550" view="false" instance="0">
             <call link="1513031148" name="PSID_Library:exciter_saturation" z="140" view="false" instance="0" />
             <call link="746068508" name="PSID_Library:exciter_saturation" z="360" view="false" instance="1" />
           </call>
         </call>
-        <call link="788221067" name="PSID_Library_Inverters:DEMETRIOUS_SG" z="-1" view="false" instance="0">
-          <call link="13104666" name="PSID_Library:BPA_GG" z="540" view="false" instance="0" />
-          <call link="1559344279" name="PSID_Library:IEEET1" z="550" view="false" instance="1">
+        <call link="408889240" name="PSID_Library_Inverters:DEMETRIOUS_SC" z="-1" view="false" instance="0">
+          <call link="1253756838" name="PSID_Library:IEEET1" z="460" view="false" instance="1">
             <call link="1513031148" name="PSID_Library:exciter_saturation" z="140" view="false" instance="2" />
             <call link="746068508" name="PSID_Library:exciter_saturation" z="360" view="false" instance="3" />
           </call>
         </call>
-        <call link="1980245536" name="PSID_Library_Inverters:SAUERPAI_SEXS_HYGOV_PSSFIXED" z="-1" view="false" instance="0">
-          <call link="522972756" name="PSID_Library:HydroTurbineGov" z="-1" view="false" instance="0" />
-          <call link="2098509671" name="PSID_Library:PSSFixed" z="-1" view="false" instance="0" />
-          <call link="1986881265" name="PSID_Library:ReferenceFrameConversion_GEN" z="460" view="false" instance="0">
-            <call link="1659966761" name="PSID_Library:timestep_delay_angle" z="40" view="false" instance="7" />
-            <call link="1136399958" name="PSID_Library:dq_abc_psid" z="50" view="false" instance="4" />
-            <call link="1050186494" name="PSID_Library:abc_dq_psid" z="60" view="false" instance="15" />
-          </call>
-          <call link="1342319537" name="PSID_Library:SingleMass" z="480" view="false" instance="0" />
-          <call link="1079232214" name="PSID_Library:CurrentSourceInterface" z="500" view="false" instance="0" />
-          <call link="1909323435" name="PSID_Library:SauerPaiMachine" z="670" view="false" instance="0" />
-          <call link="1765319643" name="PSID_Library:SEXS" z="700" view="false" instance="0" />
+        <call link="1923570403" name="PSID_Library_Inverters:SEXS_GAST" z="-1" view="false" instance="0">
+          <call link="1585206052" name="PSID_Library:SEXS" z="580" view="false" instance="0" />
         </call>
-        <call link="108144603" name="PSID_Library_Inverters:SAUERPAI_SEXS_HYGOV_IEEEST" z="-1" view="false" instance="0">
-          <call link="247362444" name="PSID_Library:HydroTurbineGov" z="-1" view="false" instance="1" />
-          <call link="1229824629" name="PSID_Library:IEEEST" z="-1" view="false" instance="0">
+        <call link="938464238" name="PSID_Library_Inverters:SIMPLE_MACHINE" z="-1" view="false" instance="0" />
+        <call link="750910413" name="PSID_Library_Inverters:SAUERPAI_SEXS_GASTG_IEEEST" z="-1" view="false" instance="0">
+          <call link="1002398144" name="PSID_Library:IEEEST" z="-1" view="false" instance="0">
             <call link="1589910882" name="PSID_Library:SecOdrPole" z="-1" view="false" instance="0" />
             <call link="617299442" name="PSID_Library:SecOdrPole" z="-1" view="false" instance="1" />
           </call>
-          <call link="438661711" name="PSID_Library:ReferenceFrameConversion_GEN" z="460" view="false" instance="1">
-            <call link="1659966761" name="PSID_Library:timestep_delay_angle" z="40" view="false" instance="8" />
-            <call link="1136399958" name="PSID_Library:dq_abc_psid" z="50" view="false" instance="5" />
-            <call link="1050186494" name="PSID_Library:abc_dq_psid" z="60" view="false" instance="16" />
+          <call link="544287701" name="PSID_Library:ReferenceFrameConversion_GEN" z="460" view="false" instance="0">
+            <call link="1659966761" name="PSID_Library:timestep_delay_angle" z="40" view="false" instance="5" />
+            <call link="1136399958" name="PSID_Library:dq_abc_psid" z="50" view="false" instance="3" />
+            <call link="1050186494" name="PSID_Library:abc_dq_psid" z="60" view="false" instance="11" />
           </call>
-          <call link="124871949" name="PSID_Library:SingleMass" z="480" view="false" instance="1" />
-          <call link="1881609797" name="PSID_Library:CurrentSourceInterface" z="500" view="false" instance="1" />
-          <call link="282512531" name="PSID_Library:SauerPaiMachine" z="670" view="false" instance="1" />
-          <call link="1762595493" name="PSID_Library:SEXS" z="700" view="false" instance="1" />
+          <call link="736631037" name="PSID_Library:SingleMass" z="480" view="false" instance="0" />
+          <call link="832841914" name="PSID_Library:CurrentSourceInterface" z="500" view="false" instance="0" />
+          <call link="1673503645" name="PSID_Library:GASTG" z="660" view="false" instance="0" />
+          <call link="1929561076" name="PSID_Library:SauerPaiMachine" z="670" view="false" instance="0" />
+          <call link="287247289" name="PSID_Library:SEXS" z="700" view="false" instance="1" />
         </call>
-        <call link="1213387110" name="PSID_Library_Inverters:SAUERPAI_SEXS_TGOV1_IEEEST" z="-1" view="false" instance="0">
-          <call link="1429635466" name="PSID_Library:SteamTurbineGov1" z="-1" view="false" instance="0" />
-          <call link="170218251" name="PSID_Library:IEEEST" z="-1" view="false" instance="1">
+        <call link="66594642" name="PSID_Library_Inverters:FIXED_SAUER_PAI" z="-1" view="false" instance="0">
+          <call link="2060554581" name="PSID_Library:PSSFixed" z="-1" view="false" instance="0" />
+          <call link="1018815231" name="PSID_Library:AVRFixed" z="450" view="false" instance="0" />
+          <call link="361948377" name="PSID_Library:ReferenceFrameConversion_GEN" z="460" view="false" instance="1">
+            <call link="1659966761" name="PSID_Library:timestep_delay_angle" z="40" view="false" instance="6" />
+            <call link="1136399958" name="PSID_Library:dq_abc_psid" z="50" view="false" instance="4" />
+            <call link="1050186494" name="PSID_Library:abc_dq_psid" z="60" view="false" instance="12" />
+          </call>
+          <call link="1589381465" name="PSID_Library:TGFixed" z="470" view="false" instance="0" />
+          <call link="1624598015" name="PSID_Library:SingleMass" z="480" view="false" instance="1" />
+          <call link="1522084081" name="PSID_Library:SauerPaiMachine" z="490" view="false" instance="1" />
+          <call link="1967639684" name="PSID_Library:CurrentSourceInterface" z="500" view="false" instance="1" />
+        </call>
+        <call link="1980245536" name="PSID_Library_Inverters:SAUERPAI_SEXS_HYGOV_PSSFIXED" z="-1" view="false" instance="0">
+          <call link="2098509671" name="PSID_Library:PSSFixed" z="-1" view="false" instance="1" />
+          <call link="522972756" name="PSID_Library:HydroTurbineGov" z="-1" view="false" instance="0" />
+          <call link="1986881265" name="PSID_Library:ReferenceFrameConversion_GEN" z="460" view="false" instance="2">
+            <call link="1659966761" name="PSID_Library:timestep_delay_angle" z="40" view="false" instance="7" />
+            <call link="1136399958" name="PSID_Library:dq_abc_psid" z="50" view="false" instance="5" />
+            <call link="1050186494" name="PSID_Library:abc_dq_psid" z="60" view="false" instance="13" />
+          </call>
+          <call link="1342319537" name="PSID_Library:SingleMass" z="480" view="false" instance="2" />
+          <call link="1079232214" name="PSID_Library:CurrentSourceInterface" z="500" view="false" instance="2" />
+          <call link="1909323435" name="PSID_Library:SauerPaiMachine" z="670" view="false" instance="2" />
+          <call link="1765319643" name="PSID_Library:SEXS" z="700" view="false" instance="2" />
+        </call>
+        <call link="108144603" name="PSID_Library_Inverters:SAUERPAI_SEXS_HYGOV_IEEEST" z="-1" view="false" instance="0">
+          <call link="247362444" name="PSID_Library:HydroTurbineGov" z="-1" view="false" instance="1" />
+          <call link="1229824629" name="PSID_Library:IEEEST" z="-1" view="false" instance="1">
             <call link="1589910882" name="PSID_Library:SecOdrPole" z="-1" view="false" instance="2" />
             <call link="617299442" name="PSID_Library:SecOdrPole" z="-1" view="false" instance="3" />
           </call>
-          <call link="827418965" name="PSID_Library:ReferenceFrameConversion_GEN" z="460" view="false" instance="2">
-            <call link="1659966761" name="PSID_Library:timestep_delay_angle" z="40" view="false" instance="9" />
+          <call link="438661711" name="PSID_Library:ReferenceFrameConversion_GEN" z="460" view="false" instance="3">
+            <call link="1659966761" name="PSID_Library:timestep_delay_angle" z="40" view="false" instance="8" />
             <call link="1136399958" name="PSID_Library:dq_abc_psid" z="50" view="false" instance="6" />
-            <call link="1050186494" name="PSID_Library:abc_dq_psid" z="60" view="false" instance="17" />
+            <call link="1050186494" name="PSID_Library:abc_dq_psid" z="60" view="false" instance="14" />
           </call>
-          <call link="1943350089" name="PSID_Library:SingleMass" z="480" view="false" instance="2" />
-          <call link="1006761352" name="PSID_Library:CurrentSourceInterface" z="500" view="false" instance="2" />
-          <call link="1888152530" name="PSID_Library:SauerPaiMachine" z="670" view="false" instance="2" />
-          <call link="862504165" name="PSID_Library:SEXS" z="700" view="false" instance="2" />
+          <call link="124871949" name="PSID_Library:SingleMass" z="480" view="false" instance="3" />
+          <call link="1881609797" name="PSID_Library:CurrentSourceInterface" z="500" view="false" instance="3" />
+          <call link="282512531" name="PSID_Library:SauerPaiMachine" z="670" view="false" instance="3" />
+          <call link="1762595493" name="PSID_Library:SEXS" z="700" view="false" instance="3" />
         </call>
-        <call link="798203330" name="PSID_Library_Inverters:SAUERPAI_SEXS_GASTG_PSSFIXED" z="-1" view="false" instance="0">
-          <call link="2074342879" name="PSID_Library:ReferenceFrameConversion_GEN" z="650" view="false" instance="3">
-            <call link="1659966761" name="PSID_Library:timestep_delay_angle" z="40" view="false" instance="10" />
-            <call link="1136399958" name="PSID_Library:dq_abc_psid" z="50" view="false" instance="7" />
-            <call link="1050186494" name="PSID_Library:abc_dq_psid" z="60" view="false" instance="18" />
-          </call>
-          <call link="1111673280" name="PSID_Library:GASTG" z="660" view="false" instance="0" />
-          <call link="1735400806" name="PSID_Library:SauerPaiMachine" z="670" view="false" instance="3" />
-          <call link="1842009857" name="PSID_Library:SingleMass" z="680" view="false" instance="3" />
-          <call link="1910789646" name="PSID_Library:PSSFixed" z="690" view="false" instance="1" />
-          <call link="12004893" name="PSID_Library:SEXS" z="700" view="false" instance="3" />
-          <call link="218071143" name="PSID_Library:CurrentSourceInterface" z="710" view="false" instance="3" />
-        </call>
-        <call link="750910413" name="PSID_Library_Inverters:SAUERPAI_SEXS_GASTG_IEEEST" z="-1" view="false" instance="0">
-          <call link="1002398144" name="PSID_Library:IEEEST" z="-1" view="false" instance="2">
+        <call link="1213387110" name="PSID_Library_Inverters:SAUERPAI_SEXS_TGOV1_IEEEST" z="-1" view="false" instance="0">
+          <call link="1429635466" name="PSID_Library:SteamTurbineGov1" z="-1" view="false" instance="0" />
+          <call link="170218251" name="PSID_Library:IEEEST" z="-1" view="false" instance="2">
             <call link="1589910882" name="PSID_Library:SecOdrPole" z="-1" view="false" instance="4" />
             <call link="617299442" name="PSID_Library:SecOdrPole" z="-1" view="false" instance="5" />
           </call>
-          <call link="544287701" name="PSID_Library:ReferenceFrameConversion_GEN" z="460" view="false" instance="4">
-            <call link="1659966761" name="PSID_Library:timestep_delay_angle" z="40" view="false" instance="11" />
+          <call link="827418965" name="PSID_Library:ReferenceFrameConversion_GEN" z="460" view="false" instance="4">
+            <call link="1659966761" name="PSID_Library:timestep_delay_angle" z="40" view="false" instance="9" />
+            <call link="1136399958" name="PSID_Library:dq_abc_psid" z="50" view="false" instance="7" />
+            <call link="1050186494" name="PSID_Library:abc_dq_psid" z="60" view="false" instance="15" />
+          </call>
+          <call link="1943350089" name="PSID_Library:SingleMass" z="480" view="false" instance="4" />
+          <call link="1006761352" name="PSID_Library:CurrentSourceInterface" z="500" view="false" instance="4" />
+          <call link="1888152530" name="PSID_Library:SauerPaiMachine" z="670" view="false" instance="4" />
+          <call link="862504165" name="PSID_Library:SEXS" z="700" view="false" instance="4" />
+        </call>
+        <call link="798203330" name="PSID_Library_Inverters:SAUERPAI_SEXS_GASTG_PSSFIXED" z="-1" view="false" instance="0">
+          <call link="2074342879" name="PSID_Library:ReferenceFrameConversion_GEN" z="650" view="false" instance="5">
+            <call link="1659966761" name="PSID_Library:timestep_delay_angle" z="40" view="false" instance="10" />
             <call link="1136399958" name="PSID_Library:dq_abc_psid" z="50" view="false" instance="8" />
-            <call link="1050186494" name="PSID_Library:abc_dq_psid" z="60" view="false" instance="19" />
+            <call link="1050186494" name="PSID_Library:abc_dq_psid" z="60" view="false" instance="16" />
           </call>
-          <call link="736631037" name="PSID_Library:SingleMass" z="480" view="false" instance="4" />
-          <call link="832841914" name="PSID_Library:CurrentSourceInterface" z="500" view="false" instance="4" />
-          <call link="1673503645" name="PSID_Library:GASTG" z="660" view="false" instance="1" />
-          <call link="1929561076" name="PSID_Library:SauerPaiMachine" z="670" view="false" instance="4" />
-          <call link="287247289" name="PSID_Library:SEXS" z="700" view="false" instance="4" />
-        </call>
-        <call link="1923570403" name="PSID_Library_Inverters:SEXS_GAST" z="-1" view="false" instance="0">
-          <call link="1585206052" name="PSID_Library:SEXS" z="580" view="false" instance="5" />
-        </call>
-        <call link="66594642" name="PSID_Library_Inverters:FIXED_SAUER_PAI" z="-1" view="false" instance="0">
-          <call link="2060554581" name="PSID_Library:PSSFixed" z="-1" view="false" instance="2" />
-          <call link="1018815231" name="PSID_Library:AVRFixed" z="450" view="false" instance="0" />
-          <call link="361948377" name="PSID_Library:ReferenceFrameConversion_GEN" z="460" view="false" instance="5">
-            <call link="1659966761" name="PSID_Library:timestep_delay_angle" z="40" view="false" instance="12" />
-            <call link="1136399958" name="PSID_Library:dq_abc_psid" z="50" view="false" instance="9" />
-            <call link="1050186494" name="PSID_Library:abc_dq_psid" z="60" view="false" instance="20" />
-          </call>
-          <call link="1589381465" name="PSID_Library:TGFixed" z="470" view="false" instance="0" />
-          <call link="1624598015" name="PSID_Library:SingleMass" z="480" view="false" instance="5" />
-          <call link="1522084081" name="PSID_Library:SauerPaiMachine" z="490" view="false" instance="5" />
-          <call link="1967639684" name="PSID_Library:CurrentSourceInterface" z="500" view="false" instance="5" />
+          <call link="1111673280" name="PSID_Library:GASTG" z="660" view="false" instance="1" />
+          <call link="1735400806" name="PSID_Library:SauerPaiMachine" z="670" view="false" instance="5" />
+          <call link="1842009857" name="PSID_Library:SingleMass" z="680" view="false" instance="5" />
+          <call link="1910789646" name="PSID_Library:PSSFixed" z="690" view="false" instance="2" />
+          <call link="12004893" name="PSID_Library:SEXS" z="700" view="false" instance="5" />
+          <call link="218071143" name="PSID_Library:CurrentSourceInterface" z="710" view="false" instance="5" />
         </call>
         <call link="1467477007" name="PSID_Library_Inverters:INFINITE_BUS" z="-1" view="false" instance="0" />
+        <call link="621267136" name="PSID_Library_Inverters:GFL_KAURA_PLL" z="-1" view="true" instance="0">
+          <call link="1462166105" name="PSID_Library:KauraPLL" z="520" view="false" instance="1">
+            <call link="2065055101" name="PSID_Library:timestep_delay_angle" z="330" view="false" instance="11" />
+            <call link="1583651100" name="PSID_Library:abc_dq_psid" z="340" view="false" instance="17" />
+          </call>
+          <call link="539411229" name="PSID_Library:FixedDCSource" z="490" view="false" instance="3" />
+          <call link="817365154" name="PSID_Library:ReferenceFrameConversion_INV" z="500" view="false" instance="3">
+            <call link="1686720077" name="PSID_Library:timestep_delay_angle" z="60" view="false" instance="12" />
+            <call link="1115078297" name="PSID_Library:dq_abc_psid" z="70" view="false" instance="9" />
+            <call link="1416558759" name="PSID_Library:abc_dq_psid" z="80" view="false" instance="18" />
+            <call link="294237646" name="PSID_Library:abc_dq_psid" z="90" view="false" instance="19" />
+            <call link="1142133084" name="PSID_Library:abc_dq_psid" z="100" view="false" instance="20" />
+          </call>
+          <call link="1559633434" name="PSID_Library:LCLFilter" z="510" view="false" instance="3">
+            <call link="645843216" name="PSID_Library:ri_abc" z="890" view="false" instance="3" />
+          </call>
+          <call link="1168180068" name="PSID_Library:ActivePI_ReactivePI" z="530" view="false" instance="1" />
+          <call link="2075316472" name="PSID_Library:CurrentModeControl" z="540" view="false" instance="1" />
+          <call link="2046628562" name="PSID_Library:AverageConverter" z="550" view="false" instance="3" />
+        </call>
         <call link="1765688990" name="PSID_Library_Inverters:SAUERPAI_SEXS_TGOV1_PSSFIXED" z="-1" view="false" instance="0">
           <call link="841156577" name="PSID_Library:ReferenceFrameConversion_GEN" z="630" view="false" instance="6">
             <call link="1659966761" name="PSID_Library:timestep_delay_angle" z="40" view="false" instance="13" />
@@ -51495,7 +51496,6 @@ https://www.phasetophase.nl/pdf/SynchronousMachineTurbineGoverningSystems.pdf]]>
           <call link="102653321" name="PSID_Library:PSSFixed" z="680" view="false" instance="3" />
           <call link="1931655674" name="PSID_Library:CurrentSourceInterface" z="690" view="false" instance="6" />
         </call>
-        <call link="938464238" name="PSID_Library_Inverters:SIMPLE_MACHINE" z="-1" view="false" instance="0" />
       </call>
     </call>
   </hierarchy>

--- a/_pscad_libraries/PSID_Library_Inverters.pslx
+++ b/_pscad_libraries/PSID_Library_Inverters.pslx
@@ -21,7 +21,7 @@
     <param name="Warn" value="0" />
     <param name="Check" value="0" />
     <param name="description" value="" />
-    <param name="revisor" value="Matt Bossart, 1677683284" />
+    <param name="revisor" value="Matt Bossart, 1678996304" />
     <param name="sparsity_threshold" value="200" />
   </paramlist>
   <Layers>
@@ -25835,6 +25835,121 @@
         <param name="ymax" value="1" />
       </paramlist>
     </Settings>
+    <Settings classid="GraphFrameSettings" id="287264289" link="1428332159">
+      <path>
+        <ref link="223495102" />
+        <ref link="621267136" />
+        <ref link="1462166105" />
+      </path>
+      <paramlist>
+        <param name="xmin" value="-1" />
+        <param name="xmax" value="1" />
+      </paramlist>
+    </Settings>
+    <Settings classid="OverlayGraphSettings" id="645545288" link="1338013808">
+      <path>
+        <ref link="223495102" />
+        <ref link="621267136" />
+        <ref link="1462166105" />
+      </path>
+      <paramlist>
+        <param name="ymin" value="-1" />
+        <param name="ymax" value="1" />
+      </paramlist>
+    </Settings>
+    <Settings classid="TraceSettings" id="395479161" link="547539101">
+      <path>
+        <ref link="223495102" />
+        <ref link="621267136" />
+        <ref link="1462166105" />
+      </path>
+      <paramlist>
+        <param name="active_1" value="true" />
+      </paramlist>
+    </Settings>
+    <Settings classid="OverlayGraphSettings" id="723782860" link="76136705">
+      <path>
+        <ref link="223495102" />
+        <ref link="621267136" />
+        <ref link="1462166105" />
+      </path>
+      <paramlist>
+        <param name="ymin" value="-1" />
+        <param name="ymax" value="1" />
+      </paramlist>
+    </Settings>
+    <Settings classid="TraceSettings" id="204985152" link="272466974">
+      <path>
+        <ref link="223495102" />
+        <ref link="621267136" />
+        <ref link="1462166105" />
+      </path>
+      <paramlist>
+        <param name="active_1" value="true" />
+      </paramlist>
+    </Settings>
+    <Settings classid="OverlayGraphSettings" id="956046629" link="1034391785">
+      <path>
+        <ref link="223495102" />
+        <ref link="621267136" />
+        <ref link="1462166105" />
+      </path>
+      <paramlist>
+        <param name="ymin" value="-1" />
+        <param name="ymax" value="1" />
+      </paramlist>
+    </Settings>
+    <Settings classid="TraceSettings" id="626470794" link="1351162954">
+      <path>
+        <ref link="223495102" />
+        <ref link="621267136" />
+        <ref link="1462166105" />
+      </path>
+      <paramlist>
+        <param name="active_1" value="true" />
+      </paramlist>
+    </Settings>
+    <Settings classid="TraceSettings" id="2076564302" link="1051270203">
+      <path>
+        <ref link="223495102" />
+        <ref link="621267136" />
+        <ref link="1462166105" />
+      </path>
+      <paramlist>
+        <param name="active_1" value="true" />
+      </paramlist>
+    </Settings>
+    <Settings classid="OverlayGraphSettings" id="1979479619" link="1627893227">
+      <path>
+        <ref link="223495102" />
+        <ref link="621267136" />
+        <ref link="1462166105" />
+      </path>
+      <paramlist>
+        <param name="ymin" value="-1" />
+        <param name="ymax" value="1" />
+      </paramlist>
+    </Settings>
+    <Settings classid="TraceSettings" id="2062897857" link="72408287">
+      <path>
+        <ref link="223495102" />
+        <ref link="621267136" />
+        <ref link="1462166105" />
+      </path>
+      <paramlist>
+        <param name="active_1" value="true" />
+      </paramlist>
+    </Settings>
+    <Settings classid="TraceSettings" id="709031496" link="1722047171">
+      <path>
+        <ref link="223495102" />
+        <ref link="621267136" />
+        <ref link="1462166105" />
+      </path>
+      <paramlist>
+        <param name="active_1" value="true" />
+      </paramlist>
+    </Settings>
   </List>
   <definitions>
     <Definition classid="UserCmpDefn" name="DEMETRIOUS_SC" group="" url="" version="" build="" crc="134199221" instances="0" key="" view="false" date="1635958333" id="550429289">
@@ -29798,7 +29913,7 @@
         </Gfx>
       </graphics>
     </Definition>
-    <Definition classid="UserCmpDefn" name="DROOP_GFM" group="" url="" version="" build="" crc="67376769" instances="0" key="" view="false" date="1677209048" id="744715342">
+    <Definition classid="UserCmpDefn" name="DROOP_GFM" group="" url="" version="" build="" crc="67376769" instances="0" key="" view="false" date="1678996054" id="744715342">
       <paramlist name="">
         <param name="Description" value="" />
       </paramlist>
@@ -32709,7 +32824,7 @@
         <grouping />
       </schematic>
     </Definition>
-    <Definition classid="UserCmpDefn" name="Main" id="1668162628" group="" url="" version="" build="" crc="120648248" view="false" date="0">
+    <Definition classid="UserCmpDefn" name="Main" id="1668162628" group="" url="" version="" build="" crc="22609555" view="false" date="0">
       <paramlist name="">
         <param name="Description" value="" />
       </paramlist>
@@ -33423,7 +33538,7 @@
             <param name="f_out" value="Freq_out" />
           </paramlist>
         </User>
-        <User classid="UserCmp" id="750910413" name="PSID_Library_Inverters:SAUERPAI_SEXS_GASTG_IEEEST" x="396" y="234" w="119" h="78" z="-1" orient="0" defn="PSID_Library_Inverters:SAUERPAI_SEXS_GASTG_IEEEST" link="-1" q="4" disable="false">
+        <User classid="UserCmp" id="750910413" name="PSID_Library_Inverters:SAUERPAI_SEXS_GASTG_IEEEST" x="396" y="234" w="118" h="78" z="-1" orient="0" defn="PSID_Library_Inverters:SAUERPAI_SEXS_GASTG_IEEEST" link="-1" q="4" disable="false">
           <paramlist name="" link="-1" crc="18129811">
             <param name="Name" value="" />
             <param name="f_base" value="60" />
@@ -33573,7 +33688,7 @@
             <param name="primemover_x0_3" value="0" />
           </paramlist>
         </User>
-        <User classid="UserCmp" id="798203330" name="PSID_Library_Inverters:SAUERPAI_SEXS_GASTG_PSSFIXED" x="396" y="324" w="119" h="78" z="-1" orient="0" defn="PSID_Library_Inverters:SAUERPAI_SEXS_GASTG_PSSFIXED" link="-1" q="4" disable="false">
+        <User classid="UserCmp" id="798203330" name="PSID_Library_Inverters:SAUERPAI_SEXS_GASTG_PSSFIXED" x="396" y="324" w="118" h="78" z="-1" orient="0" defn="PSID_Library_Inverters:SAUERPAI_SEXS_GASTG_PSSFIXED" link="-1" q="4" disable="false">
           <paramlist name="" link="-1" crc="111202234">
             <param name="Name" value="" />
             <param name="f_base" value="60" />
@@ -33694,7 +33809,7 @@
             <param name="primemover_D_turb" value="0" />
           </paramlist>
         </User>
-        <User classid="UserCmp" id="108144603" name="PSID_Library_Inverters:SAUERPAI_SEXS_HYGOV_IEEEST" x="522" y="234" w="119" h="78" z="-1" orient="0" defn="PSID_Library_Inverters:SAUERPAI_SEXS_HYGOV_IEEEST" link="-1" q="4" disable="false">
+        <User classid="UserCmp" id="108144603" name="PSID_Library_Inverters:SAUERPAI_SEXS_HYGOV_IEEEST" x="522" y="234" w="118" h="78" z="-1" orient="0" defn="PSID_Library_Inverters:SAUERPAI_SEXS_HYGOV_IEEEST" link="-1" q="4" disable="false">
           <paramlist name="" link="-1" crc="107858088">
             <param name="Name" value="" />
             <param name="f_base" value="60" />
@@ -33847,7 +33962,7 @@
             <param name="primemover_q_nl" value="0" />
           </paramlist>
         </User>
-        <User classid="UserCmp" id="1980245536" name="PSID_Library_Inverters:SAUERPAI_SEXS_HYGOV_PSSFIXED" x="522" y="324" w="119" h="78" z="-1" orient="0" defn="PSID_Library_Inverters:SAUERPAI_SEXS_HYGOV_PSSFIXED" link="-1" q="4" disable="false">
+        <User classid="UserCmp" id="1980245536" name="PSID_Library_Inverters:SAUERPAI_SEXS_HYGOV_PSSFIXED" x="522" y="324" w="118" h="78" z="-1" orient="0" defn="PSID_Library_Inverters:SAUERPAI_SEXS_HYGOV_PSSFIXED" link="-1" q="4" disable="false">
           <paramlist name="" link="-1" crc="109936304">
             <param name="Name" value="" />
             <param name="f_base" value="60" />
@@ -33962,7 +34077,7 @@
             <param name="primemover_q_nl" value="0" />
           </paramlist>
         </User>
-        <User classid="UserCmp" id="1213387110" name="PSID_Library_Inverters:SAUERPAI_SEXS_TGOV1_IEEEST" x="720" y="234" w="119" h="78" z="-1" orient="0" defn="PSID_Library_Inverters:SAUERPAI_SEXS_TGOV1_IEEEST" link="-1" q="4" disable="false">
+        <User classid="UserCmp" id="1213387110" name="PSID_Library_Inverters:SAUERPAI_SEXS_TGOV1_IEEEST" x="720" y="234" w="118" h="78" z="-1" orient="0" defn="PSID_Library_Inverters:SAUERPAI_SEXS_TGOV1_IEEEST" link="-1" q="4" disable="false">
           <paramlist name="" link="-1" crc="126701363">
             <param name="Name" value="" />
             <param name="f_base" value="60" />
@@ -34105,7 +34220,7 @@
             <param name="pss_Vcl" value="0" />
           </paramlist>
         </User>
-        <User classid="UserCmp" id="1765688990" name="PSID_Library_Inverters:SAUERPAI_SEXS_TGOV1_PSSFIXED" x="720" y="324" w="119" h="78" z="-1" orient="0" defn="PSID_Library_Inverters:SAUERPAI_SEXS_TGOV1_PSSFIXED" link="-1" q="4" disable="false">
+        <User classid="UserCmp" id="1765688990" name="PSID_Library_Inverters:SAUERPAI_SEXS_TGOV1_PSSFIXED" x="720" y="324" w="118" h="78" z="-1" orient="0" defn="PSID_Library_Inverters:SAUERPAI_SEXS_TGOV1_PSSFIXED" link="-1" q="4" disable="false">
           <paramlist name="" link="-1" crc="104761221">
             <param name="Name" value="" />
             <param name="f_base" value="60" />
@@ -48600,7 +48715,7 @@ https://www.phasetophase.nl/pdf/SynchronousMachineTurbineGoverningSystems.pdf]]>
         </Gfx>
       </graphics>
     </Definition>
-    <Definition classid="UserCmpDefn" name="SAUERPAI_SEXS_TGOV1_PSSFIXED" group="" url="" version="" build="" crc="90769185" instances="0" key="" view="false" date="1677209038" id="887792995">
+    <Definition classid="UserCmpDefn" name="SAUERPAI_SEXS_TGOV1_PSSFIXED" group="" url="" version="" build="" crc="90769185" instances="0" key="" view="false" date="1678996051" id="887792995">
       <paramlist name="">
         <param name="Description" value="" />
       </paramlist>
@@ -49826,7 +49941,7 @@ https://www.phasetophase.nl/pdf/SynchronousMachineTurbineGoverningSystems.pdf]]>
         </Gfx>
       </graphics>
     </Definition>
-    <Definition classid="UserCmpDefn" name="GFL_KAURA_PLL" group="" url="" version="" build="" crc="85570781" instances="0" key="" view="false" date="1671135954" id="1255707902">
+    <Definition classid="UserCmpDefn" name="GFL_KAURA_PLL" group="" url="" version="" build="" crc="85570781" instances="0" key="" view="false" date="1678996056" id="1255707902">
       <paramlist name="">
         <param name="Description" value="" />
       </paramlist>
@@ -51299,7 +51414,7 @@ https://www.phasetophase.nl/pdf/SynchronousMachineTurbineGoverningSystems.pdf]]>
     </paramlist>
   </GlobalSubstitutions>
   <hierarchy>
-    <call link="52356596" name="PSID_Library_Inverters:Station" z="-1" view="false" instance="0">
+    <call link="1397032866" name="PSID_Library_Inverters:Station" z="-1" view="false" instance="0">
       <call link="223495102" name="PSID_Library_Inverters:Main" z="-1" view="false" instance="0">
         <call link="238600983" name="PSID_Library_Inverters:DARCO_VSM" z="-1" view="false" instance="0">
           <call link="537476440" name="PSID_Library:ReferenceFrameConversion_INV" z="580" view="false" instance="0">
@@ -51338,6 +51453,19 @@ https://www.phasetophase.nl/pdf/SynchronousMachineTurbineGoverningSystems.pdf]]>
           <call link="2079101627" name="PSID_Library:VoltageModeControl" z="550" view="false" instance="1" />
           <call link="2040622412" name="PSID_Library:AverageConverter" z="560" view="false" instance="1" />
         </call>
+        <call link="788221067" name="PSID_Library_Inverters:DEMETRIOUS_SG" z="-1" view="false" instance="0">
+          <call link="13104666" name="PSID_Library:BPA_GG" z="540" view="false" instance="0" />
+          <call link="1559344279" name="PSID_Library:IEEET1" z="550" view="false" instance="0">
+            <call link="1513031148" name="PSID_Library:exciter_saturation" z="140" view="false" instance="0" />
+            <call link="746068508" name="PSID_Library:exciter_saturation" z="360" view="false" instance="1" />
+          </call>
+        </call>
+        <call link="408889240" name="PSID_Library_Inverters:DEMETRIOUS_SC" z="-1" view="false" instance="0">
+          <call link="1253756838" name="PSID_Library:IEEET1" z="460" view="false" instance="1">
+            <call link="1513031148" name="PSID_Library:exciter_saturation" z="140" view="false" instance="2" />
+            <call link="746068508" name="PSID_Library:exciter_saturation" z="360" view="false" instance="3" />
+          </call>
+        </call>
         <call link="439422545" name="PSID_Library_Inverters:GFL_REDUCED_PLL" z="-1" view="false" instance="0">
           <call link="1760640988" name="PSID_Library:FixedDCSource" z="480" view="false" instance="2" />
           <call link="1229355875" name="PSID_Library:ReferenceFrameConversion_INV" z="490" view="false" instance="2">
@@ -51358,71 +51486,59 @@ https://www.phasetophase.nl/pdf/SynchronousMachineTurbineGoverningSystems.pdf]]>
           <call link="2051780060" name="PSID_Library:CurrentModeControl" z="530" view="false" instance="0" />
           <call link="784303139" name="PSID_Library:AverageConverter" z="540" view="false" instance="2" />
         </call>
-        <call link="788221067" name="PSID_Library_Inverters:DEMETRIOUS_SG" z="-1" view="false" instance="0">
-          <call link="13104666" name="PSID_Library:BPA_GG" z="540" view="false" instance="0" />
-          <call link="1559344279" name="PSID_Library:IEEET1" z="550" view="false" instance="0">
-            <call link="1513031148" name="PSID_Library:exciter_saturation" z="140" view="false" instance="0" />
-            <call link="746068508" name="PSID_Library:exciter_saturation" z="360" view="false" instance="1" />
-          </call>
-        </call>
-        <call link="408889240" name="PSID_Library_Inverters:DEMETRIOUS_SC" z="-1" view="false" instance="0">
-          <call link="1253756838" name="PSID_Library:IEEET1" z="460" view="false" instance="1">
-            <call link="1513031148" name="PSID_Library:exciter_saturation" z="140" view="false" instance="2" />
-            <call link="746068508" name="PSID_Library:exciter_saturation" z="360" view="false" instance="3" />
-          </call>
-        </call>
         <call link="1923570403" name="PSID_Library_Inverters:SEXS_GAST" z="-1" view="false" instance="0">
           <call link="1585206052" name="PSID_Library:SEXS" z="580" view="false" instance="0" />
         </call>
         <call link="938464238" name="PSID_Library_Inverters:SIMPLE_MACHINE" z="-1" view="false" instance="0" />
-        <call link="750910413" name="PSID_Library_Inverters:SAUERPAI_SEXS_GASTG_IEEEST" z="-1" view="false" instance="0">
-          <call link="1002398144" name="PSID_Library:IEEEST" z="-1" view="false" instance="0">
-            <call link="1589910882" name="PSID_Library:SecOdrPole" z="-1" view="false" instance="0" />
-            <call link="617299442" name="PSID_Library:SecOdrPole" z="-1" view="false" instance="1" />
-          </call>
-          <call link="544287701" name="PSID_Library:ReferenceFrameConversion_GEN" z="460" view="false" instance="0">
+        <call link="1467477007" name="PSID_Library_Inverters:INFINITE_BUS" z="-1" view="false" instance="0" />
+        <call link="66594642" name="PSID_Library_Inverters:FIXED_SAUER_PAI" z="-1" view="false" instance="0">
+          <call link="2060554581" name="PSID_Library:PSSFixed" z="-1" view="false" instance="0" />
+          <call link="1018815231" name="PSID_Library:AVRFixed" z="450" view="false" instance="0" />
+          <call link="361948377" name="PSID_Library:ReferenceFrameConversion_GEN" z="460" view="false" instance="0">
             <call link="1659966761" name="PSID_Library:timestep_delay_angle" z="40" view="false" instance="5" />
             <call link="1136399958" name="PSID_Library:dq_abc_psid" z="50" view="false" instance="3" />
             <call link="1050186494" name="PSID_Library:abc_dq_psid" z="60" view="false" instance="11" />
           </call>
-          <call link="736631037" name="PSID_Library:SingleMass" z="480" view="false" instance="0" />
-          <call link="832841914" name="PSID_Library:CurrentSourceInterface" z="500" view="false" instance="0" />
-          <call link="1673503645" name="PSID_Library:GASTG" z="660" view="false" instance="0" />
-          <call link="1929561076" name="PSID_Library:SauerPaiMachine" z="670" view="false" instance="0" />
-          <call link="287247289" name="PSID_Library:SEXS" z="700" view="false" instance="1" />
+          <call link="1589381465" name="PSID_Library:TGFixed" z="470" view="false" instance="0" />
+          <call link="1624598015" name="PSID_Library:SingleMass" z="480" view="false" instance="0" />
+          <call link="1522084081" name="PSID_Library:SauerPaiMachine" z="490" view="false" instance="0" />
+          <call link="1967639684" name="PSID_Library:CurrentSourceInterface" z="500" view="false" instance="0" />
         </call>
-        <call link="66594642" name="PSID_Library_Inverters:FIXED_SAUER_PAI" z="-1" view="false" instance="0">
-          <call link="2060554581" name="PSID_Library:PSSFixed" z="-1" view="false" instance="0" />
-          <call link="1018815231" name="PSID_Library:AVRFixed" z="450" view="false" instance="0" />
-          <call link="361948377" name="PSID_Library:ReferenceFrameConversion_GEN" z="460" view="false" instance="1">
+        <call link="1765688990" name="PSID_Library_Inverters:SAUERPAI_SEXS_TGOV1_PSSFIXED" z="-1" view="false" instance="0">
+          <call link="841156577" name="PSID_Library:ReferenceFrameConversion_GEN" z="630" view="false" instance="1">
             <call link="1659966761" name="PSID_Library:timestep_delay_angle" z="40" view="false" instance="6" />
             <call link="1136399958" name="PSID_Library:dq_abc_psid" z="50" view="false" instance="4" />
             <call link="1050186494" name="PSID_Library:abc_dq_psid" z="60" view="false" instance="12" />
           </call>
-          <call link="1589381465" name="PSID_Library:TGFixed" z="470" view="false" instance="0" />
-          <call link="1624598015" name="PSID_Library:SingleMass" z="480" view="false" instance="1" />
-          <call link="1522084081" name="PSID_Library:SauerPaiMachine" z="490" view="false" instance="1" />
-          <call link="1967639684" name="PSID_Library:CurrentSourceInterface" z="500" view="false" instance="1" />
+          <call link="492516549" name="PSID_Library:SEXS" z="640" view="false" instance="1" />
+          <call link="1206345089" name="PSID_Library:SteamTurbineGov1" z="650" view="false" instance="0" />
+          <call link="715735346" name="PSID_Library:SingleMass" z="660" view="false" instance="1" />
+          <call link="1490332835" name="PSID_Library:SauerPaiMachine" z="670" view="false" instance="1" />
+          <call link="102653321" name="PSID_Library:PSSFixed" z="680" view="false" instance="1" />
+          <call link="1931655674" name="PSID_Library:CurrentSourceInterface" z="690" view="false" instance="1" />
         </call>
-        <call link="1980245536" name="PSID_Library_Inverters:SAUERPAI_SEXS_HYGOV_PSSFIXED" z="-1" view="false" instance="0">
-          <call link="2098509671" name="PSID_Library:PSSFixed" z="-1" view="false" instance="1" />
-          <call link="522972756" name="PSID_Library:HydroTurbineGov" z="-1" view="false" instance="0" />
-          <call link="1986881265" name="PSID_Library:ReferenceFrameConversion_GEN" z="460" view="false" instance="2">
+        <call link="750910413" name="PSID_Library_Inverters:SAUERPAI_SEXS_GASTG_IEEEST" z="-1" view="false" instance="0">
+          <call link="1002398144" name="PSID_Library:IEEEST" z="-1" view="false" instance="0">
+            <call link="617299442" name="PSID_Library:SecOdrPole" z="-1" view="false" instance="0" />
+            <call link="1589910882" name="PSID_Library:SecOdrPole" z="-1" view="false" instance="1" />
+          </call>
+          <call link="544287701" name="PSID_Library:ReferenceFrameConversion_GEN" z="460" view="false" instance="2">
             <call link="1659966761" name="PSID_Library:timestep_delay_angle" z="40" view="false" instance="7" />
             <call link="1136399958" name="PSID_Library:dq_abc_psid" z="50" view="false" instance="5" />
             <call link="1050186494" name="PSID_Library:abc_dq_psid" z="60" view="false" instance="13" />
           </call>
-          <call link="1342319537" name="PSID_Library:SingleMass" z="480" view="false" instance="2" />
-          <call link="1079232214" name="PSID_Library:CurrentSourceInterface" z="500" view="false" instance="2" />
-          <call link="1909323435" name="PSID_Library:SauerPaiMachine" z="670" view="false" instance="2" />
-          <call link="1765319643" name="PSID_Library:SEXS" z="700" view="false" instance="2" />
+          <call link="736631037" name="PSID_Library:SingleMass" z="480" view="false" instance="2" />
+          <call link="832841914" name="PSID_Library:CurrentSourceInterface" z="500" view="false" instance="2" />
+          <call link="1673503645" name="PSID_Library:GASTG" z="660" view="false" instance="0" />
+          <call link="1929561076" name="PSID_Library:SauerPaiMachine" z="670" view="false" instance="2" />
+          <call link="287247289" name="PSID_Library:SEXS" z="700" view="false" instance="2" />
         </call>
         <call link="108144603" name="PSID_Library_Inverters:SAUERPAI_SEXS_HYGOV_IEEEST" z="-1" view="false" instance="0">
-          <call link="247362444" name="PSID_Library:HydroTurbineGov" z="-1" view="false" instance="1" />
           <call link="1229824629" name="PSID_Library:IEEEST" z="-1" view="false" instance="1">
-            <call link="1589910882" name="PSID_Library:SecOdrPole" z="-1" view="false" instance="2" />
-            <call link="617299442" name="PSID_Library:SecOdrPole" z="-1" view="false" instance="3" />
+            <call link="617299442" name="PSID_Library:SecOdrPole" z="-1" view="false" instance="2" />
+            <call link="1589910882" name="PSID_Library:SecOdrPole" z="-1" view="false" instance="3" />
           </call>
+          <call link="247362444" name="PSID_Library:HydroTurbineGov" z="-1" view="false" instance="0" />
           <call link="438661711" name="PSID_Library:ReferenceFrameConversion_GEN" z="460" view="false" instance="3">
             <call link="1659966761" name="PSID_Library:timestep_delay_angle" z="40" view="false" instance="8" />
             <call link="1136399958" name="PSID_Library:dq_abc_psid" z="50" view="false" instance="6" />
@@ -51433,45 +51549,53 @@ https://www.phasetophase.nl/pdf/SynchronousMachineTurbineGoverningSystems.pdf]]>
           <call link="282512531" name="PSID_Library:SauerPaiMachine" z="670" view="false" instance="3" />
           <call link="1762595493" name="PSID_Library:SEXS" z="700" view="false" instance="3" />
         </call>
-        <call link="1213387110" name="PSID_Library_Inverters:SAUERPAI_SEXS_TGOV1_IEEEST" z="-1" view="false" instance="0">
-          <call link="1429635466" name="PSID_Library:SteamTurbineGov1" z="-1" view="false" instance="0" />
-          <call link="170218251" name="PSID_Library:IEEEST" z="-1" view="false" instance="2">
-            <call link="1589910882" name="PSID_Library:SecOdrPole" z="-1" view="false" instance="4" />
-            <call link="617299442" name="PSID_Library:SecOdrPole" z="-1" view="false" instance="5" />
-          </call>
-          <call link="827418965" name="PSID_Library:ReferenceFrameConversion_GEN" z="460" view="false" instance="4">
+        <call link="1980245536" name="PSID_Library_Inverters:SAUERPAI_SEXS_HYGOV_PSSFIXED" z="-1" view="false" instance="0">
+          <call link="2098509671" name="PSID_Library:PSSFixed" z="-1" view="false" instance="2" />
+          <call link="522972756" name="PSID_Library:HydroTurbineGov" z="-1" view="false" instance="1" />
+          <call link="1986881265" name="PSID_Library:ReferenceFrameConversion_GEN" z="460" view="false" instance="4">
             <call link="1659966761" name="PSID_Library:timestep_delay_angle" z="40" view="false" instance="9" />
             <call link="1136399958" name="PSID_Library:dq_abc_psid" z="50" view="false" instance="7" />
             <call link="1050186494" name="PSID_Library:abc_dq_psid" z="60" view="false" instance="15" />
           </call>
-          <call link="1943350089" name="PSID_Library:SingleMass" z="480" view="false" instance="4" />
-          <call link="1006761352" name="PSID_Library:CurrentSourceInterface" z="500" view="false" instance="4" />
-          <call link="1888152530" name="PSID_Library:SauerPaiMachine" z="670" view="false" instance="4" />
-          <call link="862504165" name="PSID_Library:SEXS" z="700" view="false" instance="4" />
+          <call link="1342319537" name="PSID_Library:SingleMass" z="480" view="false" instance="4" />
+          <call link="1079232214" name="PSID_Library:CurrentSourceInterface" z="500" view="false" instance="4" />
+          <call link="1909323435" name="PSID_Library:SauerPaiMachine" z="670" view="false" instance="4" />
+          <call link="1765319643" name="PSID_Library:SEXS" z="700" view="false" instance="4" />
         </call>
-        <call link="798203330" name="PSID_Library_Inverters:SAUERPAI_SEXS_GASTG_PSSFIXED" z="-1" view="false" instance="0">
-          <call link="2074342879" name="PSID_Library:ReferenceFrameConversion_GEN" z="650" view="false" instance="5">
+        <call link="1213387110" name="PSID_Library_Inverters:SAUERPAI_SEXS_TGOV1_IEEEST" z="-1" view="false" instance="0">
+          <call link="1429635466" name="PSID_Library:SteamTurbineGov1" z="-1" view="false" instance="1" />
+          <call link="170218251" name="PSID_Library:IEEEST" z="-1" view="false" instance="2">
+            <call link="617299442" name="PSID_Library:SecOdrPole" z="-1" view="false" instance="4" />
+            <call link="1589910882" name="PSID_Library:SecOdrPole" z="-1" view="false" instance="5" />
+          </call>
+          <call link="827418965" name="PSID_Library:ReferenceFrameConversion_GEN" z="460" view="false" instance="5">
             <call link="1659966761" name="PSID_Library:timestep_delay_angle" z="40" view="false" instance="10" />
             <call link="1136399958" name="PSID_Library:dq_abc_psid" z="50" view="false" instance="8" />
             <call link="1050186494" name="PSID_Library:abc_dq_psid" z="60" view="false" instance="16" />
           </call>
-          <call link="1111673280" name="PSID_Library:GASTG" z="660" view="false" instance="1" />
-          <call link="1735400806" name="PSID_Library:SauerPaiMachine" z="670" view="false" instance="5" />
-          <call link="1842009857" name="PSID_Library:SingleMass" z="680" view="false" instance="5" />
-          <call link="1910789646" name="PSID_Library:PSSFixed" z="690" view="false" instance="2" />
-          <call link="12004893" name="PSID_Library:SEXS" z="700" view="false" instance="5" />
-          <call link="218071143" name="PSID_Library:CurrentSourceInterface" z="710" view="false" instance="5" />
+          <call link="1943350089" name="PSID_Library:SingleMass" z="480" view="false" instance="5" />
+          <call link="1006761352" name="PSID_Library:CurrentSourceInterface" z="500" view="false" instance="5" />
+          <call link="1888152530" name="PSID_Library:SauerPaiMachine" z="670" view="false" instance="5" />
+          <call link="862504165" name="PSID_Library:SEXS" z="700" view="false" instance="5" />
         </call>
-        <call link="1467477007" name="PSID_Library_Inverters:INFINITE_BUS" z="-1" view="false" instance="0" />
-        <call link="621267136" name="PSID_Library_Inverters:GFL_KAURA_PLL" z="-1" view="true" instance="0">
-          <call link="1462166105" name="PSID_Library:KauraPLL" z="520" view="false" instance="1">
-            <call link="2065055101" name="PSID_Library:timestep_delay_angle" z="330" view="false" instance="11" />
-            <call link="1583651100" name="PSID_Library:abc_dq_psid" z="340" view="false" instance="17" />
+        <call link="798203330" name="PSID_Library_Inverters:SAUERPAI_SEXS_GASTG_PSSFIXED" z="-1" view="false" instance="0">
+          <call link="2074342879" name="PSID_Library:ReferenceFrameConversion_GEN" z="650" view="false" instance="6">
+            <call link="1659966761" name="PSID_Library:timestep_delay_angle" z="40" view="false" instance="11" />
+            <call link="1136399958" name="PSID_Library:dq_abc_psid" z="50" view="false" instance="9" />
+            <call link="1050186494" name="PSID_Library:abc_dq_psid" z="60" view="false" instance="17" />
           </call>
+          <call link="1111673280" name="PSID_Library:GASTG" z="660" view="false" instance="1" />
+          <call link="1735400806" name="PSID_Library:SauerPaiMachine" z="670" view="false" instance="6" />
+          <call link="1842009857" name="PSID_Library:SingleMass" z="680" view="false" instance="6" />
+          <call link="1910789646" name="PSID_Library:PSSFixed" z="690" view="false" instance="3" />
+          <call link="12004893" name="PSID_Library:SEXS" z="700" view="false" instance="6" />
+          <call link="218071143" name="PSID_Library:CurrentSourceInterface" z="710" view="false" instance="6" />
+        </call>
+        <call link="621267136" name="PSID_Library_Inverters:GFL_KAURA_PLL" z="-1" view="false" instance="0">
           <call link="539411229" name="PSID_Library:FixedDCSource" z="490" view="false" instance="3" />
           <call link="817365154" name="PSID_Library:ReferenceFrameConversion_INV" z="500" view="false" instance="3">
             <call link="1686720077" name="PSID_Library:timestep_delay_angle" z="60" view="false" instance="12" />
-            <call link="1115078297" name="PSID_Library:dq_abc_psid" z="70" view="false" instance="9" />
+            <call link="1115078297" name="PSID_Library:dq_abc_psid" z="70" view="false" instance="10" />
             <call link="1416558759" name="PSID_Library:abc_dq_psid" z="80" view="false" instance="18" />
             <call link="294237646" name="PSID_Library:abc_dq_psid" z="90" view="false" instance="19" />
             <call link="1142133084" name="PSID_Library:abc_dq_psid" z="100" view="false" instance="20" />
@@ -51479,22 +51603,13 @@ https://www.phasetophase.nl/pdf/SynchronousMachineTurbineGoverningSystems.pdf]]>
           <call link="1559633434" name="PSID_Library:LCLFilter" z="510" view="false" instance="3">
             <call link="645843216" name="PSID_Library:ri_abc" z="890" view="false" instance="3" />
           </call>
+          <call link="1462166105" name="PSID_Library:KauraPLL" z="520" view="true" instance="1">
+            <call link="2065055101" name="PSID_Library:timestep_delay_angle" z="330" view="false" instance="13" />
+            <call link="1583651100" name="PSID_Library:abc_dq_psid" z="340" view="false" instance="21" />
+          </call>
           <call link="1168180068" name="PSID_Library:ActivePI_ReactivePI" z="530" view="false" instance="1" />
           <call link="2075316472" name="PSID_Library:CurrentModeControl" z="540" view="false" instance="1" />
           <call link="2046628562" name="PSID_Library:AverageConverter" z="550" view="false" instance="3" />
-        </call>
-        <call link="1765688990" name="PSID_Library_Inverters:SAUERPAI_SEXS_TGOV1_PSSFIXED" z="-1" view="false" instance="0">
-          <call link="841156577" name="PSID_Library:ReferenceFrameConversion_GEN" z="630" view="false" instance="6">
-            <call link="1659966761" name="PSID_Library:timestep_delay_angle" z="40" view="false" instance="13" />
-            <call link="1136399958" name="PSID_Library:dq_abc_psid" z="50" view="false" instance="10" />
-            <call link="1050186494" name="PSID_Library:abc_dq_psid" z="60" view="false" instance="21" />
-          </call>
-          <call link="492516549" name="PSID_Library:SEXS" z="640" view="false" instance="6" />
-          <call link="1206345089" name="PSID_Library:SteamTurbineGov1" z="650" view="false" instance="1" />
-          <call link="715735346" name="PSID_Library:SingleMass" z="660" view="false" instance="6" />
-          <call link="1490332835" name="PSID_Library:SauerPaiMachine" z="670" view="false" instance="6" />
-          <call link="102653321" name="PSID_Library:PSSFixed" z="680" view="false" instance="3" />
-          <call link="1931655674" name="PSID_Library:CurrentSourceInterface" z="690" view="false" instance="6" />
         </call>
       </call>
     </call>

--- a/_pscad_libraries/PSID_Library_Inverters.psmx
+++ b/_pscad_libraries/PSID_Library_Inverters.psmx
@@ -1,11 +1,8 @@
 <Meta name="PSID_Library_Inverters">
-  <messagelist>
-    <message status="error" label="build" groupid="309001" id="961937604" classid="CmpNavigator">
-      <User scope="PSID_Library_Inverters" name="PSID_Library:KauraPLL" status="error" link="1462166105" /><![CDATA[Input parameter 'InitGv' is floating. The expected signal source 'INV' is undefined. ]]></message>
-  </messagelist>
+  <messagelist />
   <List classid="Settings" />
   <ViewContext>
-    <Window defn="PSID_Library_Inverters:GFL_KAURA_PLL" call="0" />
+    <Window defn="PSID_Library:KauraPLL" call="0" />
   </ViewContext>
   <List classid="View">
     <View name="Main" zoomlevel="4" scrollx="0" scrolly="72" zoomscale="1.5" />
@@ -31,7 +28,7 @@
     <View name="SAUERPAI_SEXS_HYGOV_PSSFIXED" zoomscale="0.768" scrollx="0" scrolly="0" />
     <View name="SAUERPAI_SEXS_TGOV1_IEEEST" zoomscale="0.768" scrollx="0" scrolly="0" />
     <View name="SAUERPAI_SEXS_TGOV1_PSSFIXED" zoomscale="0.768" scrollx="0" scrolly="0" />
-    <View name="GFL_KAURA_PLL" zoomscale="0.96" scrollx="0" scrolly="201" />
+    <View name="GFL_KAURA_PLL" zoomscale="0.96" scrollx="0" scrolly="0" />
     <View name="GFL_REDUCED_PLL" zoomscale="1.5" scrollx="0" scrolly="108" />
   </List>
   <Catalog count="0" />

--- a/_pscad_psid_conversion/build_system.jl
+++ b/_pscad_psid_conversion/build_system.jl
@@ -369,22 +369,21 @@ function build_component(
     add_line_breakers = false, 
     add_multimeters = false
 )
-    split_parts = split(pscad_component_name, "-")
+    #Winding #1 => from bus, Winding #2 => to bus  
+    from_bus_name = get_name(get_from(get_arc(psid_component)))
+    to_bus_name = get_name(get_to(get_arc(psid_component)))
     midpoint =
-        floor(Int, (coorDict[split_parts[1]].centerpoint[1] + coorDict[split_parts[2]].centerpoint[1]) / 2),
-        floor(Int, (coorDict[split_parts[1]].centerpoint[2] + coorDict[split_parts[2]].centerpoint[2]) / 2)
+        floor(Int, (coorDict[from_bus_name].centerpoint[1] + coorDict[to_bus_name].centerpoint[1]) / 2),
+        floor(Int, (coorDict[from_bus_name].centerpoint[2] + coorDict[to_bus_name].centerpoint[2]) / 2)
     new_xfmr = pscad_canvas.add_component("master", "xfmr-3p2w", midpoint[1], midpoint[2])
     new_xfmr.set_parameters(Name = pscad_component_name)
-    if coorDict[split_parts[2]].centerpoint[1] > coorDict[split_parts[1]].centerpoint[1]
-        new_wire =
-        pscad_canvas.add_wire(new_xfmr.get_port_location("N2"), coorDict[split_parts[2]].centerpoint)
-        new_wire2 =
-        pscad_canvas.add_wire(new_xfmr.get_port_location("N1"), coorDict[split_parts[1]].centerpoint)
+    if coorDict[to_bus_name].centerpoint[1] > coorDict[from_bus_name].centerpoint[1]
+        pscad_canvas.add_wire(new_xfmr.get_port_location("N1"), coorDict[from_bus_name].centerpoint)
+        pscad_canvas.add_wire(new_xfmr.get_port_location("N2"), coorDict[to_bus_name].centerpoint)
     else
-        new_wire =
-        pscad_canvas.add_wire(new_xfmr.get_port_location("N1"), coorDict[split_parts[2]].centerpoint)
-        new_wire2 =
-        pscad_canvas.add_wire(new_xfmr.get_port_location("N2"), coorDict[split_parts[1]].centerpoint)
+        new_xfmr.mirror()
+        pscad_canvas.add_wire(new_xfmr.get_port_location("N1"), coorDict[from_bus_name].centerpoint)
+        pscad_canvas.add_wire(new_xfmr.get_port_location("N2"), coorDict[to_bus_name].centerpoint)
     end
     new_xfmr.set_parameters(YD1 = 0, YD2 = 0)
     new_gnd = pscad_canvas.add_component("master", "ground", midpoint[1], midpoint[2]+3)

--- a/_pscad_psid_conversion/parameterize_system.jl
+++ b/_pscad_psid_conversion/parameterize_system.jl
@@ -243,10 +243,13 @@ function write_parameters(
 )
     pscad_component = pscad_project.find(pscad_component_name)
     pscad_params = pscad_component.parameters()
-
+    #Winding #1 => from bus, Winding #2 => to bus  
+    pscad_params["V1"] = get_base_voltage(get_from(get_arc(psid_component)))
+    pscad_params["V2"] = get_base_voltage(get_to(get_arc(psid_component)))
     pscad_params["Xl"] = get_x(psid_component)
     pscad_params["YD1"] = 0 # 0 means grounded wye
     pscad_params["YD2"] = 0 # 0 means grounded wye
+    pscad_params["Ideal"] = 1 # Ideal transformer model neglects magnetizing branch
     if get_r(psid_component) != 0.0
         @error "PSID component has r not equal to 0, but can't set in PSCAD"
     end

--- a/_pscad_psid_conversion/parameterize_system.jl
+++ b/_pscad_psid_conversion/parameterize_system.jl
@@ -400,13 +400,13 @@ function write_parameters(psid_component::Source, pscad_component_name, pscad_pr
     end
     pscad_params = pscad_component.parameters()
 
-    pscad_params["V_base"] = get_base_voltage(get_bus(psid_component))
-    pscad_params["S_base"] = get_base_power(psid_component)
-    pscad_params["V_pf"] = get_magnitude(get_bus(psid_component))
-    pscad_params["theta_pf"] = get_angle(get_bus(psid_component)) * (180 / pi)
-    #pscad_params["P_out"] = get_active_power(psid_component)
-    #pscad_params["Q_out"] = get_reactive_power(psid_component)
-    #pscad_params["Spec"]  = 1   #Sets Spec to be "AT_THE_TERMINAL" 
+    pscad_params["Vbase"] = get_base_voltage(get_bus(psid_component))
+    pscad_params["Sbase"] = get_base_power(psid_component)
+    pscad_params["Vpu"] = get_magnitude(get_bus(psid_component))
+    pscad_params["PhT"] = get_angle(get_bus(psid_component)) * (180 / pi)
+    pscad_params["Pinit"] = get_active_power(psid_component)
+    pscad_params["Qinit"] = get_reactive_power(psid_component)
+    pscad_params["Spec"]  = 1   #Sets Spec to be "AT_THE_TERMINAL" 
 
     PP.update_parameter_by_dictionary(pscad_component, pscad_params)
 end


### PR DESCRIPTION
- When building a transformer we need to have some concept of which winding in pscad (winding 1 and winding 2) correspond to the "to" and "from" side of the arc in PSID. So I modified the function which builds the transformer to make winding  1 and winding  2 correspond to "to" and "from" respectively. I included a call to `mirror()` to make sure the component is placed correctly. 
- Added functions to build a source in PSCAD along with two new inverter types that I already had models for (VSM and droop with reduced PLL).
- Added writing the voltage and angle and setting the conditions at the terminal when parameterizing a source.
- Parameterized the transformer winding voltages (they were unset previously, causing the 144 bus to fail).